### PR TITLE
feat: implement recommendations based on top clicked categories

### DIFF
--- a/app/src/main/java/com/example/team_23_kotlin/data/posts/FirestorePostsRepository.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/posts/FirestorePostsRepository.kt
@@ -114,5 +114,33 @@ class FirestorePostsRepository(
             .take(limit)
     }
 
+    fun getPostsByCategories(
+        categories: List<String>,
+        onResult: (List<PostEntity>) -> Unit
+    ) {
+        if (categories.isEmpty()) {
+            onResult(emptyList())
+            return
+        }
+
+        val normalized = categories.map { it.lowercase() }
+
+        db.collection("posts")
+            .whereIn("category_name", normalized.take(10)) // usar category_name
+            .get()
+            .addOnSuccessListener { result ->
+                val posts = result.mapNotNull { it.toObject(PostEntity::class.java) }
+                android.util.Log.d("RECS", "Posts encontrados: ${posts.size}")
+                onResult(posts)
+            }
+            .addOnFailureListener {
+                android.util.Log.e("RECS", "Error buscando posts", it)
+                onResult(emptyList())
+            }
+    }
+
+
+
+
 
 }

--- a/app/src/main/java/com/example/team_23_kotlin/data/posts/PostsRepository.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/posts/PostsRepository.kt
@@ -8,16 +8,29 @@ interface PostsRepository {
 
     suspend fun getNewPosts(limit: Int = 10): List<PostEntity>
     suspend fun searchPosts(query: String, limit: Int = 20): List<PostEntity>
+
 }
 
 data class PostEntity(
-    val id: String,
-    val title: String,
-    val description: String,
-    val price: Long,
-    val images: List<String>,
-    val userRef: String,
-    val status: String,
+    val id: String = "",
+    val title: String = "",
+    val description: String = "",
+    val price: Long = 0,
+    val images: List<String> = emptyList(),
+    val userRef: String = "",
+    val status: String = "",
     val createdAt: Date? = null,
     val categoryName: String = "Unknown"
-)
+) {
+    constructor() : this(
+        id = "",
+        title = "",
+        description = "",
+        price = 0,
+        images = emptyList(),
+        userRef = "",
+        status = "",
+        createdAt = null,
+        categoryName = "Unknown"
+    )
+}

--- a/app/src/main/java/com/example/team_23_kotlin/data/search/FirestoreSearchEventsRepository.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/search/FirestoreSearchEventsRepository.kt
@@ -1,0 +1,32 @@
+package com.example.team_23_kotlin.data.search
+
+import com.google.firebase.firestore.FirebaseFirestore
+
+class FirestoreSearchEventsRepository(
+    private val db: FirebaseFirestore
+) {
+    fun getTopCategoriesForUser(
+        userId: String,
+        limit: Int = 3,
+        onResult: (List<String>) -> Unit
+    ) {
+        db.collection("product_search_events")
+            .whereEqualTo("userId", userId)
+            .get()
+            .addOnSuccessListener { result ->
+                val counts = mutableMapOf<String, Int>()
+                for (doc in result) {
+                    val cat = doc.getString("selectedCategory")?.lowercase() ?: continue
+                    counts[cat] = counts.getOrDefault(cat, 0) + 1
+                }
+                val topCats = counts.entries
+                    .sortedByDescending { it.value }
+                    .take(limit)
+                    .map { it.key }
+                onResult(topCats)
+            }
+            .addOnFailureListener {
+                onResult(emptyList())
+            }
+    }
+}

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/home/RecommendationsViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/home/RecommendationsViewModel.kt
@@ -1,0 +1,38 @@
+package com.example.team_23_kotlin.presentation.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.team_23_kotlin.data.posts.FirestorePostsRepository
+import com.example.team_23_kotlin.data.posts.PostEntity
+import com.example.team_23_kotlin.data.search.FirestoreSearchEventsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class RecommendationsViewModel(
+    private val postsRepo: FirestorePostsRepository,
+    private val searchRepo: FirestoreSearchEventsRepository,
+    private val userId: String
+) : ViewModel() {
+
+    private val _recs = MutableStateFlow<List<PostEntity>>(emptyList())
+    val recs: StateFlow<List<PostEntity>> = _recs
+
+    init {
+        loadRecommendations()
+    }
+
+    private fun loadRecommendations() {
+        viewModelScope.launch {
+            searchRepo.getTopCategoriesForUser(userId) { categories ->
+                if (categories.isEmpty()) {
+                    _recs.value = emptyList()
+                    return@getTopCategoriesForUser
+                }
+                postsRepo.getPostsByCategories(categories) { posts ->
+                    _recs.value = posts
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added RecommendationsViewModel that fetches user’s top clicked categories from product_search_events.
- Integrated FirestorePostsRepository to load posts from those categories.
- Updated HomeScreen to display recommended posts dynamically in RecsCarousel.
- Ensured categories and posts are normalized (case-insensitive).

Possible fix/review: ensure UI shows all posts from selected categories (not just one per category). If current filtering logic limits results, adjust mapping in HomeScreen to use full posts list.

Closes #76 