### PR TITLE
feat: Add pickup points and recommended categories

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     // --- Hilt ---
     implementation("com.google.dagger:hilt-android:2.57.1")
+    implementation(libs.gms.play.services.maps)
     kapt("com.google.dagger:hilt-android-compiler:2.57.1")
     implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
 
@@ -111,4 +112,8 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    // --- Google Maps Compose ---
+    implementation("com.google.maps.android:maps-compose:4.4.1")
+    implementation("com.google.android.gms:play-services-maps:18.2.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,12 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Team23Kotlin">
+
+        <!-- 🔑 Agrega esto dentro de <application> -->
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyCre4oooBr4zFYj6p-p7XyMfJEnnAWOcM8" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/team_23_kotlin/data/posts/FirestorePostsRepository.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/posts/FirestorePostsRepository.kt
@@ -36,8 +36,11 @@ class FirestorePostsRepository(
                 userId = data["user_id"] as? String ?: "",     // ✅ campo correcto
                 status = data["status"] as? String ?: "",
                 createdAt = (data["created_at"] as? Timestamp)?.toDate(),
-                categoryName = categoryName
-            )
+                categoryName = categoryName,
+                pickupName = data["pickup_point_name"] as? String ?: "",
+                pickupCoords = data["pickup_coordinates"] as? String ?: "",
+
+                )
         }
     }
 
@@ -81,8 +84,11 @@ class FirestorePostsRepository(
             userId = data["user_id"] as? String ?: "",         // ✅ reemplazado userRef → userId
             status = data["status"] as? String ?: "",
             createdAt = (data["created_at"] as? Timestamp)?.toDate(),
-            categoryName = categoryName
-        )
+            categoryName = categoryName,
+            pickupName = data["pickup_point_name"] as? String ?: "",
+            pickupCoords = data["pickup_coordinates"] as? String ?: "",
+
+            )
     }
 
     // -----------------------------------------------------------
@@ -105,8 +111,11 @@ class FirestorePostsRepository(
             userId = data["user_id"] as? String ?: "",
             status = data["status"] as? String ?: "",
             createdAt = (data["created_at"] as? Timestamp)?.toDate(),
-            categoryName = categoryName
-        )
+            categoryName = categoryName,
+            pickupName = data["pickup_point_name"] as? String ?: "",
+            pickupCoords = data["pickup_coordinates"] as? String ?: "",
+
+            )
     }
 
     // -----------------------------------------------------------

--- a/app/src/main/java/com/example/team_23_kotlin/data/posts/Post.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/posts/Post.kt
@@ -13,6 +13,8 @@
         val status: String = "",
         val createdAt: Timestamp? = null,
         val category: DocumentReference? = null,
-        val userId: DocumentReference? = null
+        val userId: DocumentReference? = null,
+        val pickupName : String = "",
+        val pickupCoords : String = ""
     )
 

--- a/app/src/main/java/com/example/team_23_kotlin/data/posts/PostsRepository.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/posts/PostsRepository.kt
@@ -22,7 +22,9 @@ data class PostEntity(
     val userId: String = "",
     val status: String = "",
     val createdAt: Date? = null,
-    val categoryName: String = "Unknown"
+    val categoryName: String = "Unknown",
+    val pickupName: String = "",
+    val pickupCoords: String = ""
 ) {
     constructor() : this(
         id = "",
@@ -33,6 +35,9 @@ data class PostEntity(
         userId = "",
         status = "",
         createdAt = null,
-        categoryName = "Unknown"
+        categoryName = "Unknown",
+        pickupName = "",
+        pickupCoords = ""
+
     )
 }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/home/HomePopupState.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/home/HomePopupState.kt
@@ -1,0 +1,7 @@
+package com.example.team_23_kotlin.presentation.home
+
+data class HomePopupState(
+    val isLoading: Boolean = false,
+    val favoriteCategory: String? = null,
+    val error: String? = null
+)

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/home/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.team_23_kotlin.R
 import com.example.team_23_kotlin.data.repository.LocationRepositoryImpl
 import com.example.team_23_kotlin.domain.usecase.CheckInCampusUseCase
 import com.example.team_23_kotlin.core.ui.NetworkImage
@@ -56,7 +57,8 @@ data class ProductItem(
 fun HomeScreen(
     onGoToAuth: () -> Unit = {},
     onSearch: (String) -> Unit = {},
-    onItemClick: (String) -> Unit = {}
+    onItemClick: (String) -> Unit = {},
+    onCategoryClick: (String, String) -> Unit = { _, _ -> },
 ) {
     val postsRepo = remember { FirestorePostsRepository(FirebaseFirestore.getInstance()) }
     val postsVm: HomePostsViewModel = viewModel(factory = object : ViewModelProvider.Factory {
@@ -77,6 +79,20 @@ fun HomeScreen(
     })
 
     val isInCampus by viewModel.isInCampus.collectAsState()
+
+    val popupState by viewModel.popupState.collectAsState()
+    var showPopup by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.loadMostVisitedCategory()
+    }
+
+    LaunchedEffect(popupState.favoriteCategory) {
+        if (popupState.favoriteCategory != null) {
+            showPopup = true
+        }
+    }
+
 
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
@@ -267,6 +283,89 @@ fun HomeScreen(
             }
         }
     }
+    if (showPopup && popupState.favoriteCategory != null) {
+        val favoriteCategoryName = popupState.favoriteCategory!!.replaceFirstChar { it.uppercase() }
+
+        // Tu lista local de categorías
+        val categories = listOf(
+            Triple("Furniture", "c2", R.drawable.ic_furniture),
+            Triple("Bikes", "c3", R.drawable.ic_bikes),
+            Triple("Books", "c1", R.drawable.ic_books),
+            Triple("Electronics", "c4", R.drawable.ic_electronics),
+            Triple("Clothes", "c5", R.drawable.ic_clothes),
+            Triple("Tickets", "c6", R.drawable.ic_electronics),
+            Triple("University Club", "c7", R.drawable.ic_uni)
+        )
+
+        // Buscar coincidencia con el nombre
+        val matchedCategory = categories.firstOrNull {
+            it.first.equals(favoriteCategoryName, ignoreCase = true)
+        }
+
+        AlertDialog(
+            onDismissRequest = { showPopup = false },
+            icon = {
+                Icon(
+                    imageVector = Icons.Outlined.Search,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            },
+            title = {
+                Text(
+                    text = "👋 ¡Hola de nuevo!",
+                    style = MaterialTheme.typography.titleLarge.copy(
+                        fontWeight = FontWeight.Bold
+                    )
+                )
+            },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "Parece que te encantan los productos de la categoría ",
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Text(
+                        text = favoriteCategoryName,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = "¡Tenemos nuevas publicaciones que podrían gustarte! " +
+                                "¿Quieres verlas ahora?",
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showPopup = false
+                        matchedCategory?.let { (title, id, _) ->
+                            onCategoryClick(id, title)
+                        }
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Text("Ver publicaciones")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPopup = false }) {
+                    Text("Cerrar")
+                }
+            },
+            shape = RoundedCornerShape(20.dp),
+            containerColor = MaterialTheme.colorScheme.surface,
+            tonalElevation = 4.dp
+        )
+    }
+
+
+
 }
 
 @Composable

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/home/HomeViewModel.kt
@@ -1,10 +1,16 @@
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.team_23_kotlin.domain.usecase.CheckInCampusUseCase
+import com.example.team_23_kotlin.presentation.home.HomePopupState
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.util.Date
 
 class HomeViewModel(
     private val checkInCampusUseCase: CheckInCampusUseCase
@@ -13,10 +19,43 @@ class HomeViewModel(
     private val _isInCampus = MutableStateFlow<Boolean?>(null)
     val isInCampus: StateFlow<Boolean?> = _isInCampus.asStateFlow()
 
+    private val _popupState = MutableStateFlow(HomePopupState())
+    val popupState: StateFlow<HomePopupState> = _popupState.asStateFlow()
+
     fun refreshCampusStatus() {
         viewModelScope.launch {
             val inside = checkInCampusUseCase()
             _isInCampus.value = inside
+        }
+    }
+
+    // 🔹 Nueva función para traer la categoría más visitada
+    fun loadMostVisitedCategory() {
+        viewModelScope.launch {
+            _popupState.value = HomePopupState(isLoading = true)
+            try {
+                val userId = FirebaseAuth.getInstance().currentUser?.uid ?: return@launch
+                val firestore = FirebaseFirestore.getInstance()
+                val weekAgo = Timestamp(Date(System.currentTimeMillis() - 7L * 24 * 60 * 60 * 1000))
+
+                val snapshot = firestore.collection("product_click_events")
+                    .whereEqualTo("userId", userId)
+                    .whereGreaterThanOrEqualTo("timestamp", weekAgo)
+                    .get()
+                    .await()
+
+                val categoryCount = mutableMapOf<String, Int>()
+                for (doc in snapshot.documents) {
+                    val category = doc.getString("category") ?: continue
+                    categoryCount[category] = (categoryCount[category] ?: 0) + 1
+                }
+
+                val mostVisited = categoryCount.maxByOrNull { it.value }?.key
+                _popupState.value = HomePopupState(favoriteCategory = mostVisited)
+
+            } catch (e: Exception) {
+                _popupState.value = HomePopupState(error = e.message)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/navegation/AppNavHost.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/navegation/AppNavHost.kt
@@ -157,6 +157,9 @@ fun AppNavHost() {
                     onGoToAuth = { nav.navigate(Routes.LOGIN) },
                     onItemClick = { productId ->
                         nav.navigate("product/$productId")
+                    },
+                    onCategoryClick = { categoryId, categoryTitle ->
+                        nav.navigate(Routes.categoryFeed(categoryId, categoryTitle))
                     }
                 )
             }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostEvent.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostEvent.kt
@@ -16,4 +16,10 @@ sealed class PostEvent {
     data class PhotoRemovedAt(val index: Int): PostEvent()
 
     object SubmitClicked: PostEvent()
+
+    object ClearForm : PostEvent()
+
+    data class PickupPointSelected(val name: String, val coordinates: String) : PostEvent()
+
+
 }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostScreen.kt
@@ -49,6 +49,7 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
 
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PostScreen(
@@ -104,6 +105,44 @@ fun PostScreen(
     LaunchedEffect(s.postedOk) {
         if (s.postedOk) scope.launch { snackbarHost.showSnackbar("Post created!") }
     }
+
+    // --- Detección de sacudida del dispositivo ---
+    val sensorManager = remember { ctx.getSystemService(android.content.Context.SENSOR_SERVICE) as android.hardware.SensorManager }
+    val shakeThreshold = 50f // sensibilidad de detección (puedes ajustar)
+    var lastShakeTime by remember { mutableStateOf(0L) }
+
+    DisposableEffect(Unit) {
+        val sensorListener = object : android.hardware.SensorEventListener {
+            override fun onSensorChanged(event: android.hardware.SensorEvent?) {
+                event?.let {
+                    val x = it.values[0]
+                    val y = it.values[1]
+                    val z = it.values[2]
+                    val acceleration = kotlin.math.sqrt((x * x + y * y + z * z).toDouble()).toFloat() - 9.8f
+                    val currentTime = System.currentTimeMillis()
+
+                    // Evitar múltiples disparos seguidos
+                    if (acceleration > shakeThreshold && currentTime - lastShakeTime > 1500) {
+                        lastShakeTime = currentTime
+                        vm.onEvent(PostEvent.ClearForm)
+                        scope.launch {
+                            snackbarHost.showSnackbar("Formulario limpiado ✨")
+                        }
+                    }
+                }
+            }
+
+            override fun onAccuracyChanged(sensor: android.hardware.Sensor?, accuracy: Int) {}
+        }
+
+        val accelerometer = sensorManager.getDefaultSensor(android.hardware.Sensor.TYPE_ACCELEROMETER)
+        sensorManager.registerListener(sensorListener, accelerometer, android.hardware.SensorManager.SENSOR_DELAY_UI)
+
+        onDispose {
+            sensorManager.unregisterListener(sensorListener)
+        }
+    }
+
 
     Scaffold(
         topBar = {
@@ -207,6 +246,21 @@ fun PostScreen(
                 hint = hint,
                 imeAction = ImeAction.Done,
                 onIme = { focusManager.clearFocus() }
+            )
+
+            Spacer(Modifier.height(14.dp))
+
+
+
+            FieldLabel("Punto de recogida")
+            PickupPointDropdown(
+                pickupPoints = pickupPoints,
+                selectedName = s.pickupPointName,
+                onSelect = { point ->
+                    vm.onEvent(PostEvent.PickupPointSelected(point.name, point.coordinates))
+                },
+                hairline = hairline,
+                hint = hint
             )
 
             Spacer(Modifier.height(24.dp))
@@ -342,6 +396,74 @@ private fun CategoryDropdown(
         }
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PickupPointDropdown(
+    pickupPoints: List<PickupPoint>,
+    selectedName: String?,
+    onSelect: (PickupPoint) -> Unit,
+    hairline: androidx.compose.ui.graphics.Color,
+    hint: androidx.compose.ui.graphics.Color
+) {
+    val cs = MaterialTheme.colorScheme
+    val ty = MaterialTheme.typography
+    val shape = RoundedCornerShape(16.dp)
+    var expanded by remember { mutableStateOf(false) }
+
+    val labelText = selectedName ?: "Selecciona un punto de recogida"
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded }
+    ) {
+        TextField(
+            value = labelText,
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            singleLine = true,
+            shape = shape,
+            modifier = Modifier
+                .menuAnchor()
+                .fillMaxWidth()
+                .heightIn(min = 56.dp)
+                .border(1.dp, hairline, shape),
+            placeholder = {
+                Text("Selecciona un punto de recogida", color = hint, style = ty.bodyMedium)
+            },
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = cs.surface,
+                unfocusedContainerColor = cs.surface,
+                focusedIndicatorColor = cs.surface,
+                unfocusedIndicatorColor = cs.surface,
+                cursorColor = cs.onSurface,
+                focusedTextColor = cs.onSurface,
+                unfocusedTextColor = cs.onSurface
+            ),
+            textStyle = ty.bodyMedium.copy(
+                color = if (selectedName == null) hint else cs.onSurface,
+                platformStyle = PlatformTextStyle(includeFontPadding = false)
+            )
+        )
+
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            pickupPoints.forEach { point ->
+                DropdownMenuItem(
+                    text = { Text(point.name) },
+                    onClick = {
+                        onSelect(point)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
 
 /* ---------- Helpers y Sub-composables (sin cambios visuales) ---------- */
 

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostState.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostState.kt
@@ -5,6 +5,19 @@ data class Category(
     val name: String
 )
 
+data class PickupPoint(
+    val name: String,
+    val coordinates: String
+)
+
+val pickupPoints = listOf(
+    PickupPoint("Edificio SD", "4.6030761,-74.0676922"),
+    PickupPoint("Edificio ML", "4.6030761,-74.0676922"),
+    PickupPoint("El Bobo", "4.6012414,-74.0659291"),
+    PickupPoint("La Caneca", "4.6001055,-74.0647088")
+)
+
+
 data class PostState(
     val title: String = "",
     val description: String = "",
@@ -23,5 +36,9 @@ data class PostState(
 
     val isSaving: Boolean = false,
     val errorMessage: String? = null,
-    val postedOk: Boolean = false
-)
+    val postedOk: Boolean = false,
+
+    val pickupPointName: String? = null,
+    val pickupCoordinates: String? = null,
+
+    )

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import java.util.UUID
 import com.google.firebase.storage.ktx.storageMetadata
+import kotlinx.coroutines.flow.update
 
 class PostViewModel(
     private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance(),
@@ -57,6 +58,26 @@ class PostViewModel(
                 }
                 _state.value = _state.value.copy(photoTokens = newList)
             }
+            is PostEvent.ClearForm -> {
+                _state.update { it.copy(
+                    title = "",
+                    description = "",
+                    price = "",
+                    categoryId = null,
+                    categoryName = null,
+                    photoTokens = emptyList()
+                ) }
+            }
+            is PostEvent.PickupPointSelected -> {
+                _state.update {
+                    it.copy(
+                        pickupPointName = e.name,
+                        pickupCoordinates = e.coordinates
+                    )
+                }
+            }
+
+
 
             PostEvent.AddPhotosClick -> {}
             PostEvent.SubmitClicked -> submitPost()
@@ -108,6 +129,10 @@ class PostViewModel(
             _state.value = s.copy(errorMessage = "Please select a category.")
             return
         }
+        if (s.pickupPointName == null) {
+            _state.value = s.copy(errorMessage = "Please select a pickup point.")
+            return
+        }
 
         viewModelScope.launch {
             if (auth.currentUser == null) {
@@ -140,7 +165,9 @@ class PostViewModel(
                     "category_name" to s.categoryName,
                     "status" to "active",
                     "created_at" to FieldValue.serverTimestamp(),
-                    "user_id" to uid
+                    "user_id" to uid,
+                    "pickup_point_name" to s.pickupPointName,
+                    "pickup_coordinates" to s.pickupCoordinates
                 )
 
                 newDoc.set(data).await()

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/product/ProductScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/product/ProductScreen.kt
@@ -1,5 +1,7 @@
 package com.example.team_23_kotlin.presentation.product
 
+import android.content.Intent
+import com.example.team_23_kotlin.R
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -19,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
@@ -27,13 +30,36 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
-import com.example.team_23_kotlin.core.ui.NetworkImage
 import com.example.team_23_kotlin.data.posts.FirestorePostsRepository
 import com.example.team_23_kotlin.data.posts.PostsRepository
 import com.example.team_23_kotlin.data.repository.AnalyticsRepositoryImpl
+import com.example.team_23_kotlin.data.repository.LocationRepositoryImpl
 import com.example.team_23_kotlin.domain.repository.AnalyticsRepository
+import com.example.team_23_kotlin.domain.repository.LocationRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
+import android.net.Uri
+import android.util.Log
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.ui.input.pointer.pointerInput
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.LatLngBounds
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.Polyline
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import androidx.compose.foundation.gestures.detectTransformGestures
+import com.google.maps.android.compose.*
+import kotlinx.coroutines.*
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -218,6 +244,29 @@ fun ProductScreen(
                                 )
                             }
                         }
+                        Spacer(Modifier.height(24.dp))
+                        // 🔹 Ver punto de recogida
+                        var showMap by remember { mutableStateOf(false) }
+
+                        if (showMap && state.product != null) {
+                            PickupPointMapModal(
+                                pickupName = state.product!!.pickupName,
+                                pickupCoords = state.product!!.pickupCoords,
+                                onDismiss = { showMap = false }
+                            )
+                        }
+
+                        Button(
+                            onClick = { showMap = true },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(50.dp),
+                            shape = RoundedCornerShape(12.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                        ) {
+                            Text("Ver punto de recogida", style = MaterialTheme.typography.titleSmall)
+                        }
+
 
                         Spacer(Modifier.height(32.dp))
 
@@ -247,3 +296,243 @@ fun ProductScreen(
         }
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PickupPointMapModal(
+    pickupName: String,
+    pickupCoords: String,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val locationRepo: LocationRepository = remember { LocationRepositoryImpl(context) }
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
+    var currentLatLng by remember { mutableStateOf<LatLng?>(null) }
+    var destinationLatLng by remember { mutableStateOf<LatLng?>(null) }
+    var routePoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
+
+    val cameraPositionState = rememberCameraPositionState()
+
+    // === Parsear coordenadas del destino ===
+    LaunchedEffect(pickupCoords) {
+        try {
+            val coords = pickupCoords.split(",")
+            if (coords.size == 2) {
+                val lat = coords[0].toDoubleOrNull()
+                val lng = coords[1].toDoubleOrNull()
+                if (lat != null && lng != null)
+                    destinationLatLng = LatLng(lat, lng)
+            }
+        } catch (e: Exception) {
+            Log.e("PickupMap", "Error parseando coordenadas: $pickupCoords", e)
+        }
+    }
+
+    // === Obtener ubicación actual ===
+    LaunchedEffect(Unit) {
+        try {
+            val loc = locationRepo.getCurrentLocation()
+            loc?.let { currentLatLng = LatLng(it.latitude, it.longitude) }
+        } catch (e: Exception) {
+            Log.e("PickupMap", "Error obteniendo ubicación actual", e)
+        }
+    }
+
+    // === Obtener ruta desde Directions API ===
+    LaunchedEffect(currentLatLng, destinationLatLng) {
+        if (currentLatLng != null && destinationLatLng != null) {
+            try {
+                val url = Uri.parse(
+                    "https://maps.googleapis.com/maps/api/directions/json?" +
+                            "origin=${currentLatLng!!.latitude},${currentLatLng!!.longitude}" +
+                            "&destination=${destinationLatLng!!.latitude},${destinationLatLng!!.longitude}" +
+                            "&mode=walking" +
+                            "&key=${context.getString(R.string.google_maps_key)}"
+                ).toString()
+
+                val response = withContext(Dispatchers.IO) {
+                    java.net.URL(url).readText()
+                }
+                val json = JSONObject(response)
+                val routes = json.getJSONArray("routes")
+                if (routes.length() > 0) {
+                    val points = routes.getJSONObject(0)
+                        .getJSONObject("overview_polyline")
+                        .getString("points")
+                    routePoints = decodePolyline(points)
+
+                    val bounds = LatLngBounds.builder()
+                        .include(currentLatLng!!)
+                        .include(destinationLatLng!!)
+                        .build()
+
+                    delay(250)
+                    cameraPositionState.animate(
+                        CameraUpdateFactory.newLatLngBounds(bounds, 100)
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e("PickupMap", "Error obteniendo la ruta", e)
+            }
+        }
+    }
+
+    // === Modal con mapa ===
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState=sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+        tonalElevation = 10.dp,
+        dragHandle = { Box(Modifier.height(8.dp)) }
+    ) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                "Punto de recogida: $pickupName",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            Spacer(Modifier.height(10.dp))
+
+            // --- Mapa más pequeño (300dp)
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(300.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(Color.LightGray)
+            ) {
+                if (destinationLatLng != null) {
+                    GoogleMap(
+                        modifier = Modifier.matchParentSize(),
+                        cameraPositionState = cameraPositionState,
+                        uiSettings = MapUiSettings(
+                            zoomControlsEnabled = false,
+                            zoomGesturesEnabled = true,
+                            scrollGesturesEnabled = true
+                        ),
+                        properties = MapProperties(isMyLocationEnabled = false)
+                    ) {
+                        // Marcadores
+                        currentLatLng?.let {
+                            Marker(state = MarkerState(it), title = "Tu ubicación")
+                        }
+                        destinationLatLng?.let {
+                            Marker(state = MarkerState(it), title = pickupName)
+                        }
+                        // Ruta
+                        if (routePoints.isNotEmpty()) {
+                            Polyline(
+                                points = routePoints,
+                                color = Color(0xFF1976D2),
+                                width = 8f
+                            )
+                        }
+                    }
+
+                    // Botón pequeño “centrar” arriba a la derecha
+                    FloatingActionButton(
+                        onClick = {
+                            scope.launch {
+                                val bounds = LatLngBounds.builder()
+                                    .include(currentLatLng!!)
+                                    .include(destinationLatLng!!)
+                                    .build()
+                                cameraPositionState.animate(
+                                    CameraUpdateFactory.newLatLngBounds(bounds, 100)
+                                )
+                            }
+                        },
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(8.dp)
+                            .size(40.dp),
+                        containerColor = MaterialTheme.colorScheme.primary
+                    ) {
+                        Icon(Icons.Default.MyLocation, contentDescription = "Centrar")
+                    }
+                } else {
+                    Text(
+                        "Cargando mapa...",
+                        modifier = Modifier.align(Alignment.Center),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // --- Botón abrir en Google Maps
+            OutlinedButton(
+                onClick = {
+                    destinationLatLng?.let { dest ->
+                        val uri = Uri.parse(
+                            "https://www.google.com/maps/dir/?api=1&destination=${dest.latitude},${dest.longitude}"
+                        )
+                        val intent = Intent(Intent.ACTION_VIEW, uri)
+                        intent.setPackage("com.google.android.apps.maps")
+                        context.startActivity(intent)
+                    }
+                },
+                shape = RoundedCornerShape(10.dp),
+                border = ButtonDefaults.outlinedButtonBorder.copy(width = 1.dp)
+            ) {
+                Text("Abrir en Google Maps")
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            TextButton(onClick = onDismiss) {
+                Text("Cerrar")
+            }
+        }
+    }
+}
+
+
+/** 🔹 Decodifica la polyline del Directions API */
+fun decodePolyline(encoded: String): List<LatLng> {
+    val poly = ArrayList<LatLng>()
+    var index = 0
+    val len = encoded.length
+    var lat = 0
+    var lng = 0
+
+    while (index < len) {
+        var b: Int
+        var shift = 0
+        var result = 0
+        do {
+            b = encoded[index++].code - 63
+            result = result or (b and 0x1f shl shift)
+            shift += 5
+        } while (b >= 0x20)
+        val dlat = if ((result and 1) != 0) (result shr 1).inv() else result shr 1
+        lat += dlat
+        shift = 0
+        result = 0
+        do {
+            b = encoded[index++].code - 63
+            result = result or (b and 0x1f shl shift)
+            shift += 5
+        } while (b >= 0x20)
+        val dlng = if ((result and 1) != 0) (result shr 1).inv() else result shr 1
+        lng += dlng
+        poly.add(LatLng(lat / 1E5, lng / 1E5))
+    }
+    return poly
+}
+
+
+
+
+

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/product/ProductState.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/product/ProductState.kt
@@ -14,5 +14,7 @@ data class ProductUiModel(
     val images: List<String> = emptyList(),
     val sellerName: String,
     val sellerRating: Float,
-    val sellerId : String
+    val sellerId : String,
+    val pickupName: String,
+    val pickupCoords: String
 )

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/product/ProductViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/product/ProductViewModel.kt
@@ -37,7 +37,9 @@ class ProductViewModel(
                     images = entity.images,
                     sellerName = sellerName,
                     sellerRating = 4.5f,
-                    sellerId = entity.userId
+                    sellerId = entity.userId,
+                    pickupName = entity.pickupName,
+                    pickupCoords = entity.pickupCoords
                 )
 
                 println("📦 CategoryName being logged: ${entity.categoryName}")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="second_fragment_label">Second Fragment</string>
     <string name="next">Next</string>
     <string name="previous">Previous</string>
+    <string name="google_maps_key">AIzaSyCre4oooBr4zFYj6p-p7XyMfJEnnAWOcM8</string>
+
 
     <string name="lorem_ipsum">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam in scelerisque sem. Mauris

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ roomKtx = "2.8.0"
 foundation = "1.9.1"
 firebaseBom = "33.3.0"
 firebaseStorageKtx = "22.0.1"
+playServicesMaps = "19.2.0"
 
 [libraries]
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
@@ -78,6 +79,7 @@ foundation = { group = "androidx.compose.foundation", name = "foundation", versi
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-firestore-ktx = { module = "com.google.firebase:firebase-firestore-ktx" }
 firebase-storage-ktx = { module = "com.google.firebase:firebase-storage-ktx" }
+gms-play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit introduces two main features:

1.  **Pickup Points for Posts:**
    *   Adds a "Punto de recogida" (Pickup Point) dropdown to the post creation form.
    *   Saves the selected pickup point's name and coordinates with the post data in Firestore.
    *   On the product detail screen, a "Ver punto de recogida" button now shows a modal with a Google Map.
    *   The map displays a route from the user's current location to the pickup point.
    *   Integrates Google Maps Compose dependencies and adds the API key.

2.  **Recommended Categories Popup:**
    *   On the Home screen, a popup now appears suggesting the user's most frequently visited category from the last week.
    *   This feature is implemented by tracking `product_click_events` in Firestore.
    *   The popup provides a direct link to the feed for that category.
    *   Adds a `ClearForm` event triggered by shaking the device on the post creation screen.
    
    closes #89 