### PR TITLE
feat: Integrate Firebase Cloud Messaging for notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,9 @@ android {
 }
 
 dependencies {
+
+    // Messaging
+    implementation("com.google.firebase:firebase-messaging:23.4.0")
     // --- Firebase BoM (gestiona versiones automáticamente) ---
     implementation(platform("com.google.firebase:firebase-bom:33.3.0"))
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,9 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+
     <uses-feature
         android:name="android.hardware.camera.any"
         android:required="false" />
@@ -46,6 +49,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".notifications.MyFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+            </intent-filter>
+        </service>
+
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/example/team_23_kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/MainActivity.kt
@@ -1,20 +1,46 @@
 package com.example.team_23_kotlin
 
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.navigation.compose.rememberNavController
 import com.example.team_23_kotlin.presentation.navegation.AppNavHost
+import com.example.team_23_kotlin.presentation.navegation.Routes
 import com.example.team_23_kotlin.ui.theme.AppTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    // guardamos referencia al controlador
+    private var navControllerHolder: androidx.navigation.NavHostController? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val postIdFromNotification = intent?.getStringExtra("postId")
+        Log.d("FCM", "🔗 postId recibido en MainActivity: $postIdFromNotification")
+
         setContent {
             AppTheme {
-                AppNavHost()
+                val navController = rememberNavController()
+                navControllerHolder = navController  // guardamos referencia
+                AppNavHost(
+                    startPostId = postIdFromNotification,
+                    navController = navController
+                )
             }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        val postId = intent.getStringExtra("postId")
+        if (postId != null) {
+            Log.d("FCM", "🔄 Nuevo postId recibido: $postId")
+            navControllerHolder?.navigate(Routes.product(postId)) // 👈 Navegar directamente
         }
     }
 }

--- a/app/src/main/java/com/example/team_23_kotlin/data/posts/FirestorePostsRepository.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/posts/FirestorePostsRepository.kt
@@ -282,12 +282,12 @@ class FirestorePostsRepository(
             "price" to post.price,
             "images" to urls,
             "category_id" to post.category,
-            "category_name" to (post.category?.id ?: ""),
+            "category_name" to post.category_name,
             "status" to "active",
             "created_at" to Timestamp.now(),
             "user_id" to uid,
-            "pickup_point_name" to post.pickupName,
-            "pickup_coordinates" to post.pickupCoords
+            "pickup_point_name" to post.pickup_point_name,
+            "pickup_coordinates" to post.pickup_coordinates
         )
 
         newDoc.set(data).await()

--- a/app/src/main/java/com/example/team_23_kotlin/data/posts/Post.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/posts/Post.kt
@@ -5,16 +5,16 @@
     import com.google.firebase.firestore.DocumentReference
 
     data class Post(
-        val id: String = "",
         val title: String = "",
         val description: String = "",
         val price: Long = 0,
-        val images: List<String> = emptyList(),
-        val status: String = "",
-        val createdAt: Timestamp? = null,
         val category: DocumentReference? = null,
-        val userId: DocumentReference? = null,
-        val pickupName: String = "",
-        val pickupCoords: String? = ""
+        val category_name: String = "", // ✅ nombre de la categoría
+        val pickup_point_name: String = "", // ✅ nombre del punto
+        val pickup_coordinates: String = "", // ✅ coordenadas
+        val images: List<String> = emptyList(),
+        val user_id: String = "",
+        val created_at: String = "",
+        val status: String = "active"
     )
 

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/home/HomeViewModel.kt
@@ -5,12 +5,16 @@ import com.example.team_23_kotlin.presentation.home.HomePopupState
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import java.util.Date
+import com.google.firebase.messaging.FirebaseMessaging
+import android.util.Log
+
 
 class HomeViewModel(
     private val checkInCampusUseCase: CheckInCampusUseCase
@@ -53,9 +57,32 @@ class HomeViewModel(
                 val mostVisited = categoryCount.maxByOrNull { it.value }?.key
                 _popupState.value = HomePopupState(favoriteCategory = mostVisited)
 
+                if (mostVisited != null) {
+                    firestore.collection("users")
+                        .document(userId)
+                        .set(mapOf("favoriteCategory" to mostVisited), SetOptions.merge())
+                }
+
+                subscribeToFavoriteTopic(mostVisited)
+
+
+
             } catch (e: Exception) {
                 _popupState.value = HomePopupState(error = e.message)
             }
         }
+    }
+
+    private fun subscribeToFavoriteTopic(favoriteCategory: String?) {
+        val topic = favoriteCategory!!.lowercase()
+        FirebaseMessaging.getInstance()
+            .subscribeToTopic(topic)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    Log.d("FCM", "✅ Subscribed to topic: $topic")
+                } else {
+                    Log.e("FCM", "❌ Subscription failed", task.exception)
+                }
+            }
     }
 }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/navegation/AppNavHost.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/navegation/AppNavHost.kt
@@ -129,18 +129,24 @@ private val bottomDestinations = listOf(
 
 /** ===================== AppNavHost con BottomBar ===================== **/
 @Composable
-fun AppNavHost() {
+fun AppNavHost(
+    startPostId: String? = null,
+    navController: NavHostController = rememberNavController()
+) {
     val nav = rememberNavController()
-
     val locationViewModel: LocationViewModel = hiltViewModel()
     val sessionViewModel: SessionViewModel = hiltViewModel()
     val sessionState by sessionViewModel.state.collectAsState()
 
-    val noBottomBarRoutes = setOf(Routes.LOGIN, Routes.SIGNUP,Routes.EDIT_PROFILE, Routes.CHAT, Routes.CONFIRMPURCHASE)
+    val noBottomBarRoutes = setOf(
+        Routes.LOGIN, Routes.SIGNUP, Routes.EDIT_PROFILE,
+        Routes.CHAT, Routes.CONFIRMPURCHASE
+    )
 
     val backStackEntry by nav.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
 
+    // ✅ 1. Redirigir al Home después del login
     LaunchedEffect(sessionState.user, sessionState.isLoading) {
         if (!sessionState.isLoading && sessionState.user != null) {
             nav.navigate(Routes.HOME) {
@@ -159,14 +165,24 @@ fun AppNavHost() {
     ) { innerPadding ->
         NavHost(
             navController = nav,
-            startDestination = Routes.LOGIN,
+            startDestination = Routes.LOGIN, // 👈 siempre empieza desde aquí
             modifier = Modifier.padding(innerPadding)
         ) {
             composable(Routes.HOME) {
+                // ✅ 2. Si la app fue abierta desde notificación, redirige a Product
+                LaunchedEffect(startPostId) {
+                    if (startPostId != null) {
+                        nav.navigate(Routes.product(startPostId)) {
+                            popUpTo(Routes.HOME)
+                            launchSingleTop = true
+                        }
+                    }
+                }
+
                 HomeScreen(
                     onGoToAuth = { nav.navigate(Routes.LOGIN) },
                     onItemClick = { productId ->
-                        nav.navigate("product/$productId")
+                        nav.navigate(Routes.product(productId))
                     },
                     onCategoryClick = { categoryId, categoryTitle ->
                         nav.navigate(Routes.categoryFeed(categoryId, categoryTitle))
@@ -213,12 +229,35 @@ fun AppNavHost() {
                             onSuccess = {
                                 setLoading(false)
                                 sessionViewModel.loadUser()
-                                // navega al Home y limpia el backstack de Login
+
+                                // ✅ Forzar registro del token FCM justo después del login
+                                com.google.firebase.messaging.FirebaseMessaging.getInstance().token
+                                    .addOnSuccessListener { token ->
+                                        val firestore = com.google.firebase.firestore.FirebaseFirestore.getInstance()
+                                        val userId = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid
+                                        if (userId != null) {
+                                            val updates = mapOf(
+                                                "fcmToken" to token,
+                                                "fcmTokenUpdatedAt" to com.google.firebase.Timestamp.now()
+                                            )
+                                            firestore.collection("users").document(userId)
+                                                .set(updates, com.google.firebase.firestore.SetOptions.merge())
+                                                .addOnSuccessListener {
+                                                    android.util.Log.d("FCM", "✅ Token saved after login for user $userId")
+                                                }
+                                                .addOnFailureListener { e ->
+                                                    android.util.Log.e("FCM", "❌ Failed to save token after login", e)
+                                                }
+                                        }
+                                    }
+
+                                // Luego navega al Home
                                 nav.navigate(Routes.HOME) {
                                     popUpTo(Routes.LOGIN) { inclusive = true }
                                     launchSingleTop = true
                                 }
-                            },
+                            }
+                            ,
                             onError = { msg ->
                                 setLoading(false)
                                 error = msg

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/notifications/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/notifications/MyFirebaseMessagingService.kt
@@ -1,0 +1,98 @@
+package com.example.team_23_kotlin.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.media.RingtoneManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.example.team_23_kotlin.MainActivity
+import com.example.team_23_kotlin.R
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import android.util.Log
+
+class MyFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        Log.d("FCM", "📩 Message received from: ${remoteMessage.from}")
+        Log.d("FCM", "📦 Data payload: ${remoteMessage.data}")
+
+        // ✅ Leer datos del mensaje (vienen de la Cloud Function)
+        val title = remoteMessage.data["title"] ?: "New Product!"
+        val body = remoteMessage.data["body"] ?: "Check out what's new."
+        val postId = remoteMessage.data["postId"]
+
+        sendNotification(title, body, postId)
+    }
+
+    override fun onNewToken(token: String) {
+        Log.d("FCM", "🆕 New FCM token: $token")
+
+        val auth = com.google.firebase.auth.FirebaseAuth.getInstance()
+        val firestore = com.google.firebase.firestore.FirebaseFirestore.getInstance()
+        val userId = auth.currentUser?.uid ?: return
+
+        val userRef = firestore.collection("users").document(userId)
+        val updates = mapOf(
+            "fcmToken" to token,
+            "fcmTokenUpdatedAt" to com.google.firebase.Timestamp.now()
+        )
+
+        userRef.set(updates, com.google.firebase.firestore.SetOptions.merge())
+            .addOnSuccessListener {
+                Log.d("FCM", "✅ FCM token saved successfully for user $userId")
+            }
+            .addOnFailureListener { e ->
+                Log.e("FCM", "❌ Error saving FCM token", e)
+            }
+    }
+
+    private fun sendNotification(title: String, messageBody: String, postId: String?) {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra("postId", postId) // ✅ lo enviamos a MainActivity
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, intent,
+            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val channelId = "important_channel"
+        val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+
+        val notificationBuilder = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(title)
+            .setContentText(messageBody)
+            .setAutoCancel(true)
+            .setSound(defaultSoundUri)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setContentIntent(pendingIntent)
+
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                "Important Notifications",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Notifications for new products"
+                enableVibration(true)
+                enableLights(true)
+            }
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        notificationManager.notify(0, notificationBuilder.build())
+    }
+
+
+
+}

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/post/PostViewModel.kt
@@ -80,7 +80,8 @@ class PostViewModel(
 
             is PostEvent.PickupPointSelected -> {
                 _state.value = _state.value.copy(
-                    pickupPointName = e.name
+                    pickupPointName = e.name,
+                    pickupCoordinates = e.coordinates
                 )
             }
         }
@@ -193,6 +194,8 @@ class PostViewModel(
             return
         }
 
+
+
         viewModelScope.launch {
             try {
                 _state.value = s.copy(isSaving = true, errorMessage = null)
@@ -206,8 +209,12 @@ class PostViewModel(
                     description = s.description,
                     price = cleanPrice.toLong(),
                     category = FirebaseFirestore.getInstance()
-                        .document("/categories/${s.categoryId}")
+                        .document("/categories/${s.categoryId}"),
+                    category_name = s.categoryName ?: "",
+                    pickup_point_name = s.pickupPointName ?: "",
+                    pickup_coordinates = s.pickupCoordinates ?: "",
                 )
+
 
                 if (context == null || !isOnline(context)) {
                     // 🚫 No hay Internet → guardar borrador localmente


### PR DESCRIPTION
This commit integrates Firebase Cloud Messaging (FCM) to enable push notifications for new products.

Key changes:
- Add `firebase-messaging` dependency.
- Implement `MyFirebaseMessagingService` to handle incoming messages and display notifications.
- Update user's `fcmToken` in Firestore upon new token generation or after login.
- When a user checks in, their most visited category is saved, and they are subscribed to the corresponding FCM topic.
- Modify app navigation to handle opening a specific product page from a notification.
- Update the `Post` data model and related view models to include more details like category name and pickup point coordinates for notifications.
- Add `POST_NOTIFICATIONS` permission to the Android Manifest.

closes #107 