### PR TITLE
feat: Implement offline support and enhance chat functionality

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-25T03:01:04.777295300Z">
+        <DropdownSelection timestamp="2025-11-10T23:33:08.429389600Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=TWAISCHIOJMVF6RS" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R5CY12WRTYX" />
             </handle>
           </Target>
         </DropdownSelection>
@@ -15,7 +15,7 @@
           <targets>
             <Target type="DEFAULT_BOOT">
               <handle>
-                <DeviceId pluginId="PhysicalDevice" identifier="serial=TWAISCHIOJMVF6RS" />
+                <DeviceId pluginId="PhysicalDevice" identifier="serial=R5CW31VMM0W" />
               </handle>
             </Target>
             <Target type="DEFAULT_BOOT">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,8 +103,11 @@ dependencies {
     implementation(libs.coil.svg)
     implementation(libs.coil.gif)
 
-    // --- Room (opcional si manejas DB local) ---
-    implementation(libs.androidx.room.ktx)
+    // --- Room (local DB) ---
+    implementation("androidx.room:room-runtime:2.8.3")
+    implementation("androidx.room:room-ktx:2.8.3")
+    kapt("androidx.room:room-compiler:2.8.3")
+
 
     // --- Google Play Services ---
     implementation(libs.play.services.location)

--- a/app/src/main/java/com/example/team_23_kotlin/data/local/UserPreferences.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/local/UserPreferences.kt
@@ -1,0 +1,41 @@
+package com.example.team_23_kotlin.data.local
+
+import android.content.Context
+import androidx.datastore.preferences.core.*
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+// Extensión para acceder al DataStore
+val Context.userDataStore by preferencesDataStore("user_prefs")
+
+class UserPreferences(private val context: Context) {
+
+    companion object {
+        val NAME = stringPreferencesKey("name")
+        val PHONE = stringPreferencesKey("phone")
+        val CONTACT_PREFS = stringSetPreferencesKey("contact_prefs")
+    }
+
+    suspend fun saveProfile(name: String, phone: String, prefs: List<String>) {
+        context.userDataStore.edit { settings ->
+            settings[NAME] = name
+            settings[PHONE] = phone
+            settings[CONTACT_PREFS] = prefs.toSet()
+        }
+    }
+
+    val userProfile: Flow<UserProfile> = context.userDataStore.data.map { prefs ->
+        UserProfile(
+            name = prefs[NAME] ?: "",
+            phone = prefs[PHONE] ?: "",
+            contactPrefs = prefs[CONTACT_PREFS]?.toList() ?: emptyList()
+        )
+    }
+}
+
+data class UserProfile(
+    val name: String,
+    val phone: String,
+    val contactPrefs: List<String>
+)

--- a/app/src/main/java/com/example/team_23_kotlin/data/local/room/AppDatabase.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/local/room/AppDatabase.kt
@@ -1,0 +1,9 @@
+package com.example.team_23_kotlin.data.local.room
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [ChatEntity::class], version = 2)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun chatDao(): ChatDao
+}

--- a/app/src/main/java/com/example/team_23_kotlin/data/local/room/ChatDao.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/local/room/ChatDao.kt
@@ -1,0 +1,16 @@
+package com.example.team_23_kotlin.data.local.room
+
+import androidx.room.*
+
+@Dao
+interface ChatDao {
+
+    @Query("SELECT * FROM chats ORDER BY lastTime DESC")
+    suspend fun getAllChats(): List<ChatEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertChats(chats: List<ChatEntity>)
+
+    @Query("DELETE FROM chats")
+    suspend fun clearChats()
+}

--- a/app/src/main/java/com/example/team_23_kotlin/data/local/room/ChatEntity.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/local/room/ChatEntity.kt
@@ -1,0 +1,15 @@
+package com.example.team_23_kotlin.data.local.room
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "chats")
+data class ChatEntity(
+    @PrimaryKey val id: String,
+    val listingTitle: String,
+    val senderName: String,
+    val lastMessage: String,
+    val lastTime: String,
+    val unreadCount: Int,
+    val listingImageUrl: String? = null // ✅
+)

--- a/app/src/main/java/com/example/team_23_kotlin/data/local/room/LocalChatRepository.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/local/room/LocalChatRepository.kt
@@ -1,0 +1,10 @@
+package com.example.team_23_kotlin.data.local.room
+
+import javax.inject.Inject
+
+class LocalChatRepository @Inject constructor(
+    private val dao: ChatDao
+) {
+    suspend fun saveChats(chats: List<ChatEntity>) = dao.insertChats(chats)
+    suspend fun getChats(): List<ChatEntity> = dao.getAllChats()
+}

--- a/app/src/main/java/com/example/team_23_kotlin/data/repository/BluetoothRepositoryImpl.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/repository/BluetoothRepositoryImpl.kt
@@ -311,26 +311,34 @@ class BluetoothRepositoryImpl @Inject constructor(
 
     private fun startReadingFromSocket(socket: BluetoothSocket) {
         Log.d(TAG, "Iniciando lectura del socket...")
+
+        // Corrutina para ejecutar tareas de I/O (lectura del socket)
         readJob = CoroutineScope(Dispatchers.IO).launch {
             val buffer = ByteArray(1024)
-            var bytes: Int
             val inputStream: InputStream = socket.inputStream
 
             try {
                 while (true) {
-
-                    bytes = inputStream.read(buffer)
-
+                    // 🧠 Operación de I/O (bloqueante)
+                    val bytes = inputStream.read(buffer)
                     val message = String(buffer, 0, bytes)
                     Log.d(TAG, "Mensaje recibido: $message")
-                    _incomingMessages.emit(MessageResult.success(message))
+
+                    // ✅ Cambiamos al hilo principal para actualizar el flujo (UI o estado)
+                    withContext(Dispatchers.Main) {
+                        _incomingMessages.emit(MessageResult.success(message))
+                    }
                 }
             } catch (e: IOException) {
-                Log.e(TAG, "Error al leer mensaje: ${e.message}")
-                //_incomingMessages.emit(MessageResult.failure("Error al leer mensaje"))
+                // Si hay error, también actualizamos en Main
+                withContext(Dispatchers.Main) {
+                    Log.e(TAG, "Error al leer mensaje: ${e.message}")
+                    _incomingMessages.emit(MessageResult.failure("Error al leer mensaje"))
+                }
             }
         }
     }
+
 
 
 

--- a/app/src/main/java/com/example/team_23_kotlin/data/repository/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/repository/LocationRepositoryImpl.kt
@@ -7,7 +7,9 @@ import android.util.Log
 import com.example.team_23_kotlin.domain.repository.LocationRepository
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
 
 class LocationRepositoryImpl(private val context: Context) : LocationRepository {
@@ -16,20 +18,38 @@ class LocationRepositoryImpl(private val context: Context) : LocationRepository 
         LocationServices.getFusedLocationProviderClient(context)
     }
 
-    @SuppressLint("MissingPermission")
-    override suspend fun getCurrentLocation(): Location? = suspendCancellableCoroutine { cont ->
-        Log.d("LocationRepo", "Getting location...") // 👈 DEBUG
+//    @SuppressLint("MissingPermission")
+//    override suspend fun getCurrentLocation(): Location? = suspendCancellableCoroutine { cont ->
+//        Log.d("LocationRepo", "Getting location...") // 👈 DEBUG
+//
+//        fusedLocationClient.lastLocation
+//            .addOnSuccessListener { location ->
+//                Log.d("LocationRepo", "Got location: $location") // 👈 DEBUG
+//                cont.resume(location)
+//            }
+//            .addOnFailureListener {
+//                Log.e("LocationRepo", "Failed to get location", it) // 👈 DEBUG
+//                cont.resume(null)
+//            }
+//    }
 
-        fusedLocationClient.lastLocation
-            .addOnSuccessListener { location ->
-                Log.d("LocationRepo", "Got location: $location") // 👈 DEBUG
-                cont.resume(location)
-            }
-            .addOnFailureListener {
-                Log.e("LocationRepo", "Failed to get location", it) // 👈 DEBUG
-                cont.resume(null)
-            }
+    @SuppressLint("MissingPermission")
+    override suspend fun getCurrentLocation(): Location? = withContext(Dispatchers.IO) {
+        suspendCancellableCoroutine { cont ->
+            Log.d("LocationRepo", "Getting location...")
+
+            fusedLocationClient.lastLocation
+                .addOnSuccessListener { location ->
+                    Log.d("LocationRepo", "Got location: $location")
+                    cont.resume(location)
+                }
+                .addOnFailureListener {
+                    Log.e("LocationRepo", "Failed to get location", it)
+                    cont.resume(null)
+                }
+        }
     }
+
 
     override fun isInCampus(location: Location?): Boolean {
         val uniLatitude = 4.6014581

--- a/app/src/main/java/com/example/team_23_kotlin/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/di/DatabaseModule.kt
@@ -1,0 +1,27 @@
+package com.example.team_23_kotlin.di
+
+import android.content.Context
+import androidx.room.Room
+import com.example.team_23_kotlin.data.local.room.AppDatabase
+import com.example.team_23_kotlin.data.local.room.ChatDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+        Room.databaseBuilder(context, AppDatabase::class.java, "marketplace_db")
+            .fallbackToDestructiveMigration(true)
+            .build()
+
+    @Provides
+    fun provideChatDao(db: AppDatabase): ChatDao = db.chatDao()
+}

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/chat/ChatBackup.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/chat/ChatBackup.kt
@@ -1,0 +1,8 @@
+package com.example.team_23_kotlin.presentation.chat
+
+data class ChatBackup(
+    val chatId: String,
+    val peerName: String,
+    val listingTitle: String?,
+    val messages: List<ChatMessage>
+)

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/chat/ChatScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material.icons.outlined.AttachFile
 import androidx.compose.material.icons.outlined.Send
@@ -25,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.example.team_23_kotlin.utils.isNetworkAvailable
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -35,13 +37,25 @@ fun ChatScreen(
 ) {
     val vm: ChatViewModel = hiltViewModel()
     val state by vm.state.collectAsState()
+    val exportMessage by vm.exportMessage.collectAsState() // 👈 observamos el mensaje de exportación
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     // 🔹 Cargar el chat al entrar
     LaunchedEffect(chatId) {
         vm.loadChat(chatId)
     }
 
+    // 🔹 Mostrar Snackbar cuando cambie el mensaje de exportación
+    LaunchedEffect(exportMessage) {
+        exportMessage?.let { msg ->
+            scope.launch { snackbarHostState.showSnackbar(msg) }
+        }
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) }, // 👈 habilitamos Snackbar
         topBar = {
             CenterAlignedTopAppBar(
                 navigationIcon = {
@@ -71,6 +85,7 @@ fun ChatScreen(
                         }
                     }
                 },
+
                 colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                     containerColor = MaterialTheme.colorScheme.background,
                     titleContentColor = MaterialTheme.colorScheme.primary
@@ -170,9 +185,9 @@ fun ChatScreen(
                 }
             }
         }
-
     }
 }
+
 
 /* ---------- UI PIECES ---------- */
 

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/chat/ChatViewModel.kt
@@ -1,7 +1,10 @@
 package com.example.team_23_kotlin.presentation.chat
 
+import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.util.LruCache
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -13,16 +16,27 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import com.google.firebase.firestore.MetadataChanges
+import com.google.gson.Gson
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
 
 
 @HiltViewModel
 class ChatViewModel @Inject constructor(
     private val firestore: FirebaseFirestore,
-    private val auth: FirebaseAuth
+    private val auth: FirebaseAuth,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ChatState())
     val state: StateFlow<ChatState> = _state.asStateFlow()
+    private val _exportMessage = MutableStateFlow<String?>(null)
+    val exportMessage: StateFlow<String?> = _exportMessage.asStateFlow()
+
+
+    private val messageCache = LruCache<String, List<ChatMessage>>(5)
+
+    private val gson = Gson()
 
     // =====================================================
     // 🔹 Cargar un chat específico
@@ -30,13 +44,20 @@ class ChatViewModel @Inject constructor(
     fun loadChat(chatId: String) {
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true, error = null)
+            messageCache.get(chatId)?.let { cachedMessages ->
+                _state.value = _state.value.copy(
+                    messages = cachedMessages,
+                    isLoading = false,
+                    error = null
+                )
+                Log.d("ChatViewModel", "⚡ Mensajes cargados desde memoria (LRUCache)")
+                return@launch
+            }
 
             try {
+                // Intentar cargar el chat desde Firestore
                 val chatDoc = firestore.collection("chats").document(chatId).get().await()
-                if (!chatDoc.exists()) {
-                    _state.value = _state.value.copy(error = "Chat not found", isLoading = false)
-                    return@launch
-                }
+                if (!chatDoc.exists()) throw Exception("Chat not found")
 
                 val data = chatDoc.data ?: emptyMap()
                 val productId = data["product_id"] as? String
@@ -70,10 +91,37 @@ class ChatViewModel @Inject constructor(
 
             } catch (e: Exception) {
                 e.printStackTrace()
-                _state.value = _state.value.copy(error = e.message, isLoading = false)
+                Log.e("ChatViewModel", "Error loading from Firestore: ${e.message}")
+
+                // Si Firestore falla, intentar cargar respaldo local
+                val file = File(context.filesDir, "chat_${chatId}.json")
+                if (file.exists()) {
+                    try {
+                        val json = file.readText()
+                        val backup = gson.fromJson(json, ChatBackup::class.java)
+
+                        _state.value = _state.value.copy(
+                            header = ChatHeader(
+                                chatId = backup.chatId,
+                                peerName = backup.peerName,
+                                listingTitle = backup.listingTitle
+                            ),
+                            messages = backup.messages,
+                            isLoading = false,
+                            error = null
+                        )
+
+                        _exportMessage.value = "💾 Chat cargado desde respaldo local"
+                    } catch (ex: Exception) {
+                        _state.value = _state.value.copy(error = "Error leyendo respaldo local")
+                    }
+                } else {
+                    _state.value = _state.value.copy(error = "No se pudo cargar el chat")
+                }
             }
         }
     }
+
 
     // =====================================================
     // 🔹 Escuchar mensajes en tiempo real
@@ -108,7 +156,25 @@ class ChatViewModel @Inject constructor(
                     )
                 } ?: emptyList()
 
+                // 🔹 Guarda los mensajes en la caché
+                messageCache.put(chatId, messages)
+                Log.d("ChatViewModel", "💨 Mensajes guardados en LRUCache (${messages.size})")
+
                 _state.value = _state.value.copy(messages = messages)
+                try {
+                    val backup = ChatBackup(
+                        chatId = chatId,
+                        peerName = _state.value.header.peerName,
+                        listingTitle = _state.value.header.listingTitle,
+                        messages = messages
+                    )
+                    val file = File(context.filesDir, "chat_${chatId}.json")
+                    file.writeText(gson.toJson(backup))
+                    Log.d("ChatViewModel", "💾 Respaldo local actualizado")
+                } catch (ex: Exception) {
+                    Log.e("ChatViewModel", "Error guardando respaldo local: ${ex.message}")
+                }
+
             }
     }
 
@@ -215,5 +281,53 @@ class ChatViewModel @Inject constructor(
 
     fun clearError() {
         _state.value = _state.value.copy(error = null)
+    }
+    // =====================================================
+    // 🔹 Exportar chat a archivo local JSON
+    // =====================================================
+    fun exportChatToJson() {
+        viewModelScope.launch {
+            try {
+                val chatId = _state.value.header.chatId
+                val messages = _state.value.messages
+
+                if (messages.isEmpty()) {
+                    Log.e("ChatViewModel", "No messages to export")
+                    return@launch
+                }
+
+                val exportData = mapOf(
+                    "chatId" to chatId,
+                    "peerName" to _state.value.header.peerName,
+                    "listingTitle" to _state.value.header.listingTitle,
+                    "messages" to messages.map {
+                        mapOf(
+                            "sender" to it.senderName,
+                            "text" to it.text,
+                            "timestamp" to it.timestamp,
+                            "isMine" to it.isMine,
+                            "status" to it.deliveryStatus.name
+                        )
+                    }
+                )
+
+                val file = File(context.filesDir, "chat_${chatId}.json")
+                file.writeText(gson.toJson(exportData))
+                _exportMessage.value = "✅ Chat exportado correctamente"
+                println("✅ Chat exportado correctamente a ${file.absolutePath}")
+                Log.e("ChatViewModel", "✅ Chat exportado correctamente a ${file.absolutePath}")
+
+
+
+                // (Opcional) feedback en UI
+                _state.value = _state.value.copy(
+                    error = null
+                )
+
+            } catch (e: Exception) {
+                e.printStackTrace()
+                _state.value = _state.value.copy(error = "Error al exportar chat: ${e.message}")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/chatlist/ChatListScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/chatlist/ChatListScreen.kt
@@ -149,8 +149,8 @@ private fun ChatRow(
                 .clip(RoundedCornerShape(8.dp))
         ) {
             AsyncImage(
-                model =  "https://picsum.photos/200",
-                contentDescription = null,
+                model = data.listingImageUrl ?: "https://picsum.photos/200",
+                contentDescription = "Product image",
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop
                 )

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/chatlist/ChatListState.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/chatlist/ChatListState.kt
@@ -12,6 +12,7 @@ data class ChatSummary(
     val senderName: String,
     val lastMessage: String,
     val lastTime: String,
-    val unreadCount: Int
+    val unreadCount: Int,
+    val listingImageUrl: String? = null
 )
 

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/chatlist/ChatListViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/chatlist/ChatListViewModel.kt
@@ -2,6 +2,8 @@ package com.example.team_23_kotlin.presentation.chatlist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.team_23_kotlin.data.local.room.ChatEntity
+import com.example.team_23_kotlin.data.local.room.LocalChatRepository
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -21,7 +23,8 @@ import javax.inject.Inject
 @HiltViewModel
 class ChatListViewModel @Inject constructor(
     private val auth: FirebaseAuth,
-    private val firestore: FirebaseFirestore
+    private val firestore: FirebaseFirestore,
+    private val localRepo: LocalChatRepository
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ChatListState())
@@ -40,6 +43,7 @@ class ChatListViewModel @Inject constructor(
 
     private var listenerRegistration: ListenerRegistration? = null
 
+
     private fun loadChats() {
         val currentUser = auth.currentUser ?: run {
             _state.update { it.copy(error = "User not logged in", isLoading = false) }
@@ -49,10 +53,31 @@ class ChatListViewModel @Inject constructor(
         val uid = currentUser.uid
         _state.update { it.copy(isLoading = true, error = null) }
 
-        // 🔹 Eliminar listener previo si ya existía
         listenerRegistration?.remove()
 
-        // 🔹 Escuchar cambios en tiempo real
+        // 🔹 Primero intenta cargar los chats locales (modo offline)
+        viewModelScope.launch {
+            val localChats = localRepo.getChats()
+            if (localChats.isNotEmpty()) {
+                _state.update {
+                    it.copy(
+                        chats = localChats.map { chat ->
+                            ChatSummary(
+                                id = chat.id,
+                                listingTitle = chat.listingTitle,
+                                senderName = chat.senderName,
+                                lastMessage = chat.lastMessage,
+                                lastTime = chat.lastTime,
+                                unreadCount = chat.unreadCount
+                            )
+                        },
+                        isLoading = false
+                    )
+                }
+            }
+        }
+
+        // 🔹 Luego escucha los cambios en Firestore (modo online)
         listenerRegistration = firestore.collection("chats")
             .whereArrayContains("participant_ids", uid)
             .addSnapshotListener { snapshot, error ->
@@ -65,41 +90,66 @@ class ChatListViewModel @Inject constructor(
                     val data = doc.data ?: return@mapNotNull null
                     val productId = data["product_id"] as? String
 
-                    var productTitle = "Product"
-                    try {
-                        if (!productId.isNullOrEmpty()) {
-                            // ⚠️ No uses await aquí (snapshotListener no soporta suspending)
-                            firestore.collection("posts").document(productId).get()
-                                .addOnSuccessListener { postDoc ->
-                                    val title = postDoc.getString("title") ?: "Product"
-                                    _state.update { s ->
-                                        val newChats = s.chats.map {
-                                            if (it.id == doc.id) it.copy(listingTitle = title) else it
-                                        }
-                                        s.copy(chats = newChats)
+                    var listingTitle = "Product"
+                    var imageUrl: String? = null
+
+                    if (!productId.isNullOrEmpty()) {
+                        firestore.collection("posts").document(productId).get()
+                            .addOnSuccessListener { postDoc ->
+                                listingTitle = postDoc.getString("title") ?: "Product"
+                                val images = postDoc.get("images") as? List<*>
+                                val imageUrl = images?.firstOrNull() as? String
+
+
+                                _state.update { s ->
+                                    val newChats = s.chats.map {
+                                        if (it.id == doc.id) it.copy(
+                                            listingTitle = listingTitle,
+                                            listingImageUrl = imageUrl
+                                        ) else it
                                     }
+                                    s.copy(chats = newChats)
                                 }
-                        }
-                    } catch (_: Exception) { }
+                            }
+                    }
 
                     ChatSummary(
                         id = doc.id,
-                        listingTitle = productTitle,
+                        listingTitle = listingTitle,
                         senderName = getParticipantName(uid, data),
                         lastMessage = data["last_message"] as? String ?: "",
                         lastTime = formatTimestamp(data["updated_at"]),
-                        unreadCount = getUnreadCountForUser(uid, data)
+                        unreadCount = getUnreadCountForUser(uid, data),
+                        listingImageUrl = imageUrl // ✅ nuevo campo
                     )
                 } ?: emptyList()
 
-                // 🔹 Ordenar por fecha de actualización
+
                 val sortedChats = chats.sortedByDescending { it.lastTime }
 
+                // 🔹 Actualiza UI
                 _state.update {
                     it.copy(chats = sortedChats, isLoading = false, error = null)
                 }
+
+                // 🔹 Guarda localmente los chats
+                viewModelScope.launch {
+                    val entities = sortedChats.map {
+                        ChatEntity(
+                            id = it.id,
+                            listingTitle = it.listingTitle,
+                            senderName = it.senderName,
+                            lastMessage = it.lastMessage,
+                            lastTime = it.lastTime,
+                            unreadCount = it.unreadCount,
+                            listingImageUrl = it.listingImageUrl
+                        )
+                    }
+                    localRepo.saveChats(entities)
+                }
             }
     }
+
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/editprofile/EditProfileScreen.kt
@@ -127,31 +127,6 @@ fun EditProfileScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-// EMAIL FIELD
-            Column(modifier = Modifier.fillMaxWidth()) {
-                Text(
-                    text = "Email",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.Black,
-                    modifier = Modifier.padding(bottom = 4.dp)
-                )
-                TextField(
-                    value = state.email ?: "",
-                    onValueChange = { viewModel.onEvent(EditProfileEvent.OnEmailChanged(it)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    shape = RoundedCornerShape(8.dp),
-                    colors = TextFieldDefaults.colors(
-                        focusedContainerColor = Color(0xFFF0F0F0),
-                        unfocusedContainerColor = Color(0xFFF0F0F0),
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent
-                    )
-                )
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
 // PHONE FIELD
             Column(modifier = Modifier.fillMaxWidth()) {
                 Text(

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/editprofile/EditProfileViewModel.kt
@@ -3,6 +3,7 @@ package com.example.team_23_kotlin.presentation.editprofile
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.team_23_kotlin.data.local.UserPreferences
 import com.example.team_23_kotlin.utils.isNetworkAvailable
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -23,84 +24,112 @@ class EditProfileViewModel @Inject constructor(
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
+    private val prefs = UserPreferences(context)
+
     private val _state = MutableStateFlow(EditProfileState())
     val state: StateFlow<EditProfileState> = _state.asStateFlow()
 
     init {
-        loadUserData()
+        // 1️⃣ Cargar siempre primero lo local
+        loadLocalData()
+        // 2️⃣ Luego intentar sincronizar con Firestore si hay conexión
+        syncLocalToRemote()
     }
 
     // ============================================================
-    // 🔹 Cargar datos del usuario (con cache Firestore)
+    // 🔹 Cargar datos locales desde DataStore
     // ============================================================
-    private fun loadUserData() {
+    private fun loadLocalData() {
         viewModelScope.launch {
-            val uid = auth.currentUser?.uid ?: return@launch
-
-            try {
-                val doc = firestore.collection("users").document(uid).get().await()
-                if (doc.exists()) {
-                    val data = doc.data ?: return@launch
-                    _state.update {
-                        it.copy(
-                            name = data["name"] as? String ?: "",
-                            email = data["email"] as? String ?: "",
-                            phone = data["phone"] as? String ?: "",
-                            role = data["role"] as? String ?: "",
-                            contactPreferences = (data["contact_preferences"] as? List<String>) ?: emptyList()
-                        )
-                    }
+            prefs.userProfile.collect { local ->
+                _state.update {
+                    it.copy(
+                        name = local.name,
+                        phone = local.phone,
+                        contactPreferences = local.contactPrefs
+                    )
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
-                _state.update { it.copy(error = e.message ?: "Error loading profile") }
             }
         }
     }
 
     // ============================================================
-    // 🔹 Manejo de eventos
+    // 🔹 Intentar sincronizar datos locales a Firestore al iniciar
     // ============================================================
-    fun onEvent(event: EditProfileEvent) {
-        when (event) {
-            is EditProfileEvent.OnNameChanged -> _state.update { it.copy(name = event.value) }
-            is EditProfileEvent.OnEmailChanged -> _state.update { it.copy(email = event.value) }
-            is EditProfileEvent.OnPhoneChanged -> _state.update { it.copy(phone = event.value) }
-            is EditProfileEvent.OnSaveClicked -> saveChanges()
-            is EditProfileEvent.OnContactPrefsChanged -> _state.update { it.copy(contactPreferences = event.value) }
+    private fun syncLocalToRemote() {
+        viewModelScope.launch {
+            if (!isNetworkAvailable(context)) return@launch
+
+            val uid = auth.currentUser?.uid ?: return@launch
+            val local = prefs.userProfile // obtener los últimos datos locales
+
+            local.collect { data ->
+                try {
+                    val updates = mapOf(
+                        "name" to data.name,
+                        "phone" to data.phone,
+                        "contact_preferences" to data.contactPrefs,
+                        "updated_at" to com.google.firebase.Timestamp.now()
+                    )
+                    firestore.collection("users").document(uid).update(updates).await()
+                    _state.update { it.copy(success = true, error = null) }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
         }
     }
 
     // ============================================================
-    // 🔹 Guardar cambios (con verificación de red)
+    // 🔹 Manejar eventos
+    // ============================================================
+    fun onEvent(event: EditProfileEvent) {
+        when (event) {
+            is EditProfileEvent.OnNameChanged -> _state.update { it.copy(name = event.value) }
+            is EditProfileEvent.OnPhoneChanged -> _state.update { it.copy(phone = event.value) }
+            is EditProfileEvent.OnContactPrefsChanged -> _state.update { it.copy(contactPreferences = event.value) }
+            is EditProfileEvent.OnSaveClicked -> saveChanges()
+            else -> {}
+        }
+    }
+
+    // ============================================================
+    // 🔹 Guardar cambios (offline/online)
     // ============================================================
     private fun saveChanges() {
         viewModelScope.launch {
             val uid = auth.currentUser?.uid ?: return@launch
+            val s = _state.value
 
-            // 🔸 Verificar conexión antes de guardar
+            _state.update { it.copy(isSaving = true, error = null, success = false) }
+
+            // 🔸 1. Guardar SIEMPRE localmente
+            prefs.saveProfile(
+                name = s.name,
+                phone = s.phone ?: "",
+                prefs = s.contactPreferences
+            )
+
             if (!isNetworkAvailable(context)) {
+                // 🔸 2. Si no hay conexión, avisar que se guardó localmente
                 _state.update {
                     it.copy(
                         isSaving = false,
-                        success = false,
-                        error = "No internet connection. Try again when you're online."
+                        success = true,
+                        error = "Changes saved locally. Will sync when online."
                     )
                 }
                 return@launch
             }
 
-            _state.update { it.copy(isSaving = true, error = null, success = false) }
-
             try {
+                // 🔸 3. Si hay conexión, también subir a Firestore
                 val updates = mapOf(
-                    "name" to _state.value.name,
-                    "email" to _state.value.email,
-                    "phone" to _state.value.phone,
-                    "contact_preferences" to _state.value.contactPreferences,
+                    "name" to s.name,
+                    "phone" to s.phone,
+                    "contact_preferences" to s.contactPreferences,
                     "updated_at" to com.google.firebase.Timestamp.now()
                 )
-
                 firestore.collection("users").document(uid).update(updates).await()
 
                 _state.update {
@@ -116,7 +145,7 @@ class EditProfileViewModel @Inject constructor(
                     it.copy(
                         isSaving = false,
                         success = false,
-                        error = "Failed to update profile: ${e.message}"
+                        error = "Failed to sync with server: ${e.message}"
                     )
                 }
             }


### PR DESCRIPTION
This commit introduces significant offline capabilities and several feature enhancements across the chat and user profile sections.

**Features:**

*   **Offline Chat Support:**
    *   The chat list now caches data locally using Room database, allowing users to view their conversations even when offline.
    *   Individual chat messages are cached in memory (LRUCache) and backed up to a local JSON file, ensuring access to recent conversations without a network connection.
    *   The app now loads local data first for a faster, offline-first experience, then syncs with Firestore when online.

*   **Edit Profile with Offline Support:**
    *   User profile data is now saved to local DataStore, enabling offline profile editing.
    *   Changes are saved locally first and then synchronized with Firestore when a network connection is available.

*   **Chat Enhancements:**
    *   The chat list now displays the image of the listed product next to each conversation.
    *   Added the ability to export a chat conversation to a local JSON file.

**Refactoring and Fixes:**

*   **Dependencies:** Added Room dependencies for local database storage.
*   **Data Models:** Updated `ChatSummary` and created `ChatEntity` to support local caching, including the product image URL.
*   **ViewModel Logic:** Refactored `ChatListViewModel`, `ChatViewModel`, and `EditProfileViewModel` to handle the offline-first data loading and synchronization logic.
*   **UI:** Removed the non-editable email field from the "Edit Profile" screen.

closes #119 