### PR TITLE
feat(purchases): Add My Purchases screen and PDF receipt generation

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-11-10T23:33:08.429389600Z">
+        <DropdownSelection timestamp="2025-11-19T03:19:10.636811Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=R5CY12WRTYX" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -57,5 +57,6 @@
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="UsePropertyAccessSyntax" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/app/src/main/java/com/example/team_23_kotlin/data/local/room/AppDatabase.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/local/room/AppDatabase.kt
@@ -3,7 +3,9 @@ package com.example.team_23_kotlin.data.local.room
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [ChatEntity::class], version = 2)
+@Database(entities = [ChatEntity::class, ReceiptEntity::class], version = 3)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun chatDao(): ChatDao
+
+    abstract fun receiptDao(): ReceiptDao
 }

--- a/app/src/main/java/com/example/team_23_kotlin/data/local/room/ReceiptDao.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/local/room/ReceiptDao.kt
@@ -1,0 +1,19 @@
+package com.example.team_23_kotlin.data.local.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface ReceiptDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(receipt: ReceiptEntity)
+
+    @Query("SELECT * FROM receipts WHERE purchaseId = :id LIMIT 1")
+    suspend fun getReceipt(id: String): ReceiptEntity?
+
+    @Query("SELECT purchaseId FROM receipts")
+    suspend fun getAll(): List<String>
+}

--- a/app/src/main/java/com/example/team_23_kotlin/data/local/room/ReceiptEntity.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/local/room/ReceiptEntity.kt
@@ -1,0 +1,10 @@
+package com.example.team_23_kotlin.data.local.room
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "receipts")
+data class ReceiptEntity(
+    @PrimaryKey val purchaseId: String,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/example/team_23_kotlin/data/purchases/PurchaseEntity.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/purchases/PurchaseEntity.kt
@@ -1,0 +1,23 @@
+package com.example.team_23_kotlin.data.purchases
+
+import java.util.Date
+
+data class PurchaseEntity(
+    val id: String = "",
+    val postId: String = "",
+    val title: String = "",
+    val description: String = "",
+    val price: Double = 0.0,
+    val postImages: List<String> = emptyList(),
+
+    val sellerId: String = "",
+    val sellerName: String = "",
+    val sellerImage: String? = null,
+
+    val buyerId: String = "",
+    val buyerName: String = "",
+
+    val status: String = "pending", // pending | completed
+    val createdAt: Date = Date(),
+    val isDownloaded: Boolean = false
+)

--- a/app/src/main/java/com/example/team_23_kotlin/data/repository/BluetoothRepositoryImpl.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/repository/BluetoothRepositoryImpl.kt
@@ -319,12 +319,12 @@ class BluetoothRepositoryImpl @Inject constructor(
 
             try {
                 while (true) {
-                    // 🧠 Operación de I/O (bloqueante)
+
                     val bytes = inputStream.read(buffer)
                     val message = String(buffer, 0, bytes)
                     Log.d(TAG, "Mensaje recibido: $message")
 
-                    // ✅ Cambiamos al hilo principal para actualizar el flujo (UI o estado)
+
                     withContext(Dispatchers.Main) {
                         _incomingMessages.emit(MessageResult.success(message))
                     }

--- a/app/src/main/java/com/example/team_23_kotlin/data/repository/PurchasesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/repository/PurchasesRepositoryImpl.kt
@@ -1,0 +1,158 @@
+package com.example.team_23_kotlin.data.repository
+
+import android.os.Build
+import android.util.Log
+import com.example.team_23_kotlin.data.purchases.PurchaseEntity
+import com.example.team_23_kotlin.domain.repository.PurchasesRepository
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Source
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import android.util.LruCache
+import androidx.annotation.RequiresApi
+import com.example.team_23_kotlin.data.local.room.ReceiptDao
+import com.example.team_23_kotlin.data.local.room.ReceiptEntity
+import com.google.firebase.auth.FirebaseAuth
+
+
+class PurchasesRepositoryImpl @Inject constructor(
+    private val db: FirebaseFirestore,
+    private val receiptDao: ReceiptDao
+
+) : PurchasesRepository {
+    private val purchasesLruCache = object : LruCache<String, PurchaseEntity>(10) {}
+
+
+    companion object {
+        private const val TAG = "PurchasesRepositoryImpl"
+        private const val COLLECTION_SALES = "sales"
+        private const val COLLECTION_USERS = "users"
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override suspend fun getPurchases(): List<PurchaseEntity> {
+        // 1. Si ya tenemos cache, devolverla inmediatamente
+        if (purchasesLruCache.size() > 0) {
+            val cachedList = purchasesLruCache.snapshot().values.toList()
+            if (cachedList.isNotEmpty()) return cachedList
+        }
+
+        return try {
+            val uid = FirebaseAuth.getInstance().uid ?: return emptyList()
+
+            val snapshot = db.collection(COLLECTION_SALES)
+                .whereEqualTo("buyer_ref", db.document("$COLLECTION_USERS/$uid"))
+                .get(Source.SERVER)
+                .await()
+
+            val purchases = snapshot.documents.mapNotNull { doc ->
+                mapToPurchaseEntity(doc)
+            }
+
+            // 🔥 GUARDAR EN CACHE LRU
+            purchases.forEach { purchase ->
+                purchasesLruCache.put(purchase.id, purchase)
+            }
+
+            purchases
+
+        } catch (e: Exception) {
+
+            // 🔥 Si falla Firestore: regresar lo que haya en cache
+            val cached = mutableListOf<PurchaseEntity>()
+            for (key in purchasesLruCache.snapshot().keys) {
+                purchasesLruCache.get(key)?.let { cached.add(it) }
+            }
+
+            if (cached.isNotEmpty()) return cached
+
+            emptyList()
+        }
+    }
+
+
+    override suspend fun savePurchasesToLocal(purchases: List<PurchaseEntity>) {
+        // Not implemented (you said no cache)
+    }
+
+    override suspend fun getLocalPurchases(): List<PurchaseEntity> {
+        // Not implemented
+        return emptyList()
+    }
+
+    // ========================
+// 🔥 ROOM: RECIBOS
+// ========================
+
+    override suspend fun markReceiptGenerated(purchaseId: String) {
+        receiptDao.insert(
+            ReceiptEntity(
+                purchaseId = purchaseId,
+                timestamp = System.currentTimeMillis()
+            )
+        )
+    }
+
+    override suspend fun isReceiptGenerated(purchaseId: String): Boolean {
+        return receiptDao.getReceipt(purchaseId) != null
+    }
+
+    override suspend fun getAllGeneratedReceipts(): List<String> {
+        return receiptDao.getAll()
+    }
+
+
+    // 📌 Mapea documento → PurchaseEntity
+    private suspend fun mapToPurchaseEntity(doc: DocumentSnapshot): PurchaseEntity? {
+        return try {
+            val data = doc.data ?: return null
+
+            val buyerRef = data["buyer_ref"] as? com.google.firebase.firestore.DocumentReference
+            val sellerRef = data["seller_ref"] as? com.google.firebase.firestore.DocumentReference
+            val postRef   = data["post_ref"] as? com.google.firebase.firestore.DocumentReference
+
+            val buyerId = buyerRef?.id ?: ""
+            val sellerId = sellerRef?.id ?: ""
+            val postId = postRef?.id ?: ""
+
+            // 🟦 Obtener datos del post
+            val postData = try { postRef?.get()?.await()?.data } catch (_: Exception) { null }
+            val title = postData?.get("title") as? String ?: "No title"
+            val images = (postData?.get("images") as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+            val price = (data["price"] as? Number)?.toDouble() ?: 0.0
+
+            // 🟩 Obtener nombre del vendedor
+            val sellerData = try { sellerRef?.get()?.await()?.data } catch (_: Exception) { null }
+            val sellerName = sellerData?.get("name") as? String ?: "Unknown seller"
+
+            // 🟨 Obtener nombre del comprador (opcional)
+            val buyerData = try { buyerRef?.get()?.await()?.data } catch (_: Exception) { null }
+            val buyerName = buyerData?.get("name") as? String ?: "Unknown buyer"
+
+            val status = data["status"] as? String ?: "pending"
+            val createdAt = (data["created_at"] as? Timestamp)?.toDate() ?: java.util.Date()
+
+            // 🔥 Crear entidad final
+            PurchaseEntity(
+                id = doc.id,
+                postId = postId,
+                title = title,
+                description = "",
+                price = price,
+                postImages = images,
+                sellerId = sellerId,
+                sellerName = sellerName,
+                buyerId = buyerId,
+                buyerName = buyerName,
+                status = status,
+                createdAt = createdAt
+            )
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Error mapping purchase document", e)
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/example/team_23_kotlin/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/di/DatabaseModule.kt
@@ -24,4 +24,7 @@ object DatabaseModule {
 
     @Provides
     fun provideChatDao(db: AppDatabase): ChatDao = db.chatDao()
+
+    @Provides
+    fun provideReceiptDao(db: AppDatabase) = db.receiptDao()
 }

--- a/app/src/main/java/com/example/team_23_kotlin/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/di/RepositoryModule.kt
@@ -8,8 +8,10 @@ import com.example.team_23_kotlin.data.repository.LocationRepositoryImpl
 import com.example.team_23_kotlin.core.network.hasInternetConnection
 import com.example.team_23_kotlin.data.local.SalesCacheStorage
 import com.example.team_23_kotlin.data.local.SharedSalesMemoryCache
+import com.example.team_23_kotlin.data.repository.PurchasesRepositoryImpl
 import com.example.team_23_kotlin.data.sales.SalesRepository
 import com.example.team_23_kotlin.data.sales.FirestoreSalesRepository
+import com.example.team_23_kotlin.domain.repository.PurchasesRepository
 import com.google.firebase.firestore.FirebaseFirestore
 import dagger.Binds
 import dagger.Module
@@ -29,6 +31,13 @@ abstract class RepositoryModule {
     abstract fun bindAnalyticsRepository(
         impl: AnalyticsRepositoryImpl
     ): AnalyticsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPurchasesRepository(
+        impl: PurchasesRepositoryImpl
+    ): PurchasesRepository
+
 
     companion object {
         // 🔹 Provee LocationRepository (usa @Provides porque necesita Context)

--- a/app/src/main/java/com/example/team_23_kotlin/domain/repository/PurchasesRepository.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/domain/repository/PurchasesRepository.kt
@@ -1,0 +1,14 @@
+package com.example.team_23_kotlin.domain.repository
+
+import com.example.team_23_kotlin.data.purchases.PurchaseEntity
+
+interface PurchasesRepository {
+    suspend fun getPurchases(): List<PurchaseEntity>
+    suspend fun savePurchasesToLocal(purchases: List<PurchaseEntity>)
+    suspend fun getLocalPurchases(): List<PurchaseEntity>
+
+    suspend fun markReceiptGenerated(purchaseId: String)
+    suspend fun isReceiptGenerated(purchaseId: String): Boolean
+    suspend fun getAllGeneratedReceipts(): List<String>
+
+}

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/navegation/AppNavHost.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/navegation/AppNavHost.kt
@@ -40,6 +40,8 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.ui.unit.sp
 import android.net.Uri
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.remember
@@ -59,6 +61,7 @@ import com.example.team_23_kotlin.presentation.auth.SignUpScreen
 import com.example.team_23_kotlin.presentation.categories.CategoryFeedScreen
 import com.example.team_23_kotlin.presentation.confirmpurchase.ConfirmPurchaseScreen
 import com.example.team_23_kotlin.presentation.confirmpurchase.ConfirmPurchaseViewModel
+import com.example.team_23_kotlin.presentation.purchases.PurchasesScreen
 import com.example.team_23_kotlin.presentation.sales.SalesScreen
 
 
@@ -85,6 +88,9 @@ object Routes {
     const val CONFIRMPURCHASE = "confirmpurchase/{chatId}"
     fun confirmPurchase(chatId: String) = "confirmpurchase/${Uri.encode(chatId)}"
     const val SALES = "sales"
+
+    const val PURCHASES = "purchases"
+
 }
 
 /** ===================== Bottom Destinations ===================== **/
@@ -130,6 +136,7 @@ private val bottomDestinations = listOf(
 )
 
 /** ===================== AppNavHost con BottomBar ===================== **/
+@RequiresApi(Build.VERSION_CODES.Q)
 @Composable
 fun AppNavHost(
     startPostId: String? = null,
@@ -142,7 +149,7 @@ fun AppNavHost(
 
     val noBottomBarRoutes = setOf(
         Routes.LOGIN, Routes.SIGNUP, Routes.EDIT_PROFILE,
-        Routes.CHAT, Routes.CONFIRMPURCHASE, Routes.SALES
+        Routes.CHAT, Routes.CONFIRMPURCHASE, Routes.SALES, Routes.PURCHASES
     )
 
     val backStackEntry by nav.currentBackStackEntryAsState()
@@ -330,7 +337,9 @@ fun AppNavHost(
                     onProductClick = { productId ->
                         nav.navigate("product/$productId")
                     },
-                    onGoToSales = { nav.navigate(Routes.SALES) }
+                    onGoToSales = { nav.navigate(Routes.SALES) },
+                    onGoToPurchases = { nav.navigate(Routes.PURCHASES) }
+
                 )
             }
 
@@ -417,6 +426,13 @@ fun AppNavHost(
                     onBack = { nav.popBackStack() }
                 )
             }
+
+            composable(Routes.PURCHASES) {
+                PurchasesScreen(
+                    onBack = { nav.popBackStack() }
+                )
+            }
+
         }
     }
 }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/profile/ProfileScreen.kt
@@ -38,8 +38,10 @@ fun ProfileScreen(
     locationViewModel: LocationViewModel,
     onProductClick: (String) -> Unit,
     onGoToSales: () -> Unit = {},
+    onGoToPurchases: () -> Unit = {},   // 👈 AÑADIR ESTA LÍNEA
     viewModel: ProfileViewModel = hiltViewModel()
-) {
+)
+ {
     val state by viewModel.state.collectAsState()
     val isInCampus by locationViewModel.isInCampus.collectAsState()
     val context = LocalContext.current
@@ -231,6 +233,26 @@ fun ProfileScreen(
                                 style = MaterialTheme.typography.titleSmall
                             )
                         }
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        Button(
+                            onClick = { onGoToPurchases() },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(40.dp),
+                            shape = RoundedCornerShape(7.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                        ) {
+                            Text(
+                                "Purchases",
+                                color = Color.White,
+                                style = MaterialTheme.typography.titleSmall
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
 
                         Spacer(modifier = Modifier.height(48.dp))
 

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesEvent.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesEvent.kt
@@ -1,0 +1,12 @@
+package com.example.team_23_kotlin.presentation.purchases
+
+import com.example.team_23_kotlin.data.purchases.PurchaseEntity
+
+sealed class PurchasesEvent {
+    object OnRefresh : PurchasesEvent()
+    data class OnTabChange(val tab: PurchasesTab) : PurchasesEvent()
+
+    data class OnDownloadReceipt(val purchase: PurchaseEntity) : PurchasesEvent()
+
+
+}

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesScreen.kt
@@ -1,0 +1,387 @@
+package com.example.team_23_kotlin.presentation.purchases
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import com.example.team_23_kotlin.data.purchases.PurchaseEntity
+import com.example.team_23_kotlin.presentation.shared.rememberConnectivityStatus
+import java.text.SimpleDateFormat
+import java.util.*
+
+@RequiresApi(Build.VERSION_CODES.Q)
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PurchasesScreen(
+    onBack: () -> Unit = {},
+    viewModel: PurchasesViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val isConnected by rememberConnectivityStatus()
+    var wasOffline by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isConnected) {
+        if (isConnected) {
+            if (wasOffline) {
+                snackbarHostState.showSnackbar("Conexión restaurada. Actualizando compras…")
+                viewModel.onEvent(PurchasesEvent.OnRefresh)
+                wasOffline = false
+            }
+        } else {
+            wasOffline = true
+            snackbarHostState.showSnackbar("Conexión perdida. Mostrando compras guardadas.")
+        }
+    }
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        "My Purchases",
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = Color.White
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Filled.ArrowBack, null, tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { paddingValues ->
+        when {
+            state.isLoading -> Box(
+                Modifier.fillMaxSize().padding(paddingValues),
+                Alignment.Center
+            ) { CircularProgressIndicator() }
+
+            state.error != null -> Box(
+                Modifier.fillMaxSize().padding(paddingValues),
+                Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(state.error ?: "Unknown error")
+                    Button(onClick = { viewModel.onEvent(PurchasesEvent.OnRefresh) }) {
+                        Text("Retry")
+                    }
+                }
+            }
+
+            else -> PurchasesContent(
+                state = state,
+                onEvent = viewModel::onEvent,
+                modifier = Modifier.padding(paddingValues)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PurchasesContent(
+    state: PurchasesState,
+    onEvent: (PurchasesEvent) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        PurchasesStatsSection(
+            total = state.totalPurchased,
+            completed = state.totalCompleted,
+            pending = state.totalPending,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(16.dp)
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        PurchasesTabRow(
+            currentTab = state.currentTab,
+            onTabChange = { onEvent(PurchasesEvent.OnTabChange(it)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        if (state.filteredPurchases.isEmpty()) {
+            Box(Modifier.fillMaxSize(), Alignment.Center) {
+                Text("No purchases to display", color = Color.Gray)
+            }
+        } else {
+            LazyColumn(
+                Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(state.filteredPurchases) { purchase ->
+                    PurchaseCard(
+                        purchase = purchase,
+                        onReceiptAction = {
+                            onEvent(PurchasesEvent.OnDownloadReceipt(it))
+                        }
+
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatCard(
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.headlineMedium.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 32.sp
+            ),
+            color = Color.Black
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.Gray
+        )
+    }
+}
+
+
+@Composable
+private fun PurchasesStatsSection(
+    total: Int,
+    completed: Int,
+    pending: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier, horizontalArrangement = Arrangement.SpaceEvenly) {
+        StatCard(value = total.toString(), label = "Total", modifier = Modifier.weight(1f))
+        Spacer(Modifier.width(12.dp))
+        StatCard(value = completed.toString(), label = "Completed", modifier = Modifier.weight(1f))
+        Spacer(Modifier.width(12.dp))
+        StatCard(value = pending.toString(), label = "Pending", modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun PurchasesTabRow(
+    currentTab: PurchasesTab,
+    onTabChange: (PurchasesTab) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        PurchasesTabButton("All", currentTab == PurchasesTab.ALL, { onTabChange(PurchasesTab.ALL) })
+        Spacer(Modifier.width(8.dp))
+        PurchasesTabButton("Pending", currentTab == PurchasesTab.PENDING, { onTabChange(PurchasesTab.PENDING) })
+        Spacer(Modifier.width(8.dp))
+        PurchasesTabButton("Completed", currentTab == PurchasesTab.COMPLETED, { onTabChange(PurchasesTab.COMPLETED) })
+    }
+}
+
+@Composable
+private fun PurchasesTabButton(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Box(
+        Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (selected) MaterialTheme.colorScheme.primary else Color(0xFFF0F0F0))
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp, horizontal = 12.dp),
+        Alignment.Center
+    ) {
+        Text(
+            text,
+            fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+            color = if (selected) Color.White else Color.Gray
+        )
+    }
+}
+
+@Composable
+private fun PurchaseCard(
+    purchase: PurchaseEntity,
+    onReceiptAction: (PurchaseEntity) -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                if (purchase.postImages.isNotEmpty()) {
+                    AsyncImage(
+                        model = purchase.postImages.first(),
+                        contentDescription = purchase.title,
+                        modifier = Modifier.size(60.dp).clip(RoundedCornerShape(8.dp)),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        purchase.title,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Bold
+                        ),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        "$${purchase.price}",
+                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                    )
+                }
+
+                PurchaseStatusBadge(status = purchase.status)
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            Row(
+                Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(Icons.Filled.Person, contentDescription = null, tint = Color.Gray, modifier = Modifier.size(16.dp))
+                Text(
+                    purchase.sellerName,
+                    color = Color.Gray,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    formatDate(purchase.createdAt),
+                    color = Color.Gray,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+            // 🔥 Si ya fue descargado → abrir PDF
+            if (purchase.isDownloaded) {
+                Button(
+                    onClick = { onReceiptAction(purchase) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF4CAF50)
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("Abrir PDF", color = Color.White)
+                }
+            }
+// 🧾 Si NO ha sido descargado → generar PDF
+            else {
+                Button(
+                    onClick = { onReceiptAction(purchase) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("Descargar recibo", color = Color.White)
+                }
+            }
+
+
+        }
+    }
+}
+
+@Composable
+private fun PurchaseStatusBadge(status: String) {
+    val (label, bg, color) = when (status) {
+        "pending" -> Triple("Pending", Color(0xFFFFF3E0), Color(0xFFFF6F00))
+        "completed" -> Triple("Completed", Color(0xFFE8F5E9), Color(0xFF2E7D32))
+        else -> Triple(status, Color(0xFFF5F5F5), Color.Gray)
+    }
+
+    Box(
+        Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(bg)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Text(label, color = color, fontWeight = FontWeight.Bold)
+    }
+}
+
+private fun formatDate(date: Date?): String {
+    if (date == null) return "No date"
+
+    val now = Date()
+    val diff = now.time - date.time
+    val hours = diff / (1000 * 60 * 60)
+    val days = hours / 24
+
+    return when {
+        hours < 1 -> "Less than 1h ago"
+        hours < 24 -> "$hours hour${if (hours != 1L) "s" else ""} ago"
+        days < 7 -> "$days day${if (days != 1L) "s" else ""} ago"
+        else -> SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()).format(date)
+    }
+}

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesState.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesState.kt
@@ -1,0 +1,17 @@
+package com.example.team_23_kotlin.presentation.purchases
+
+import com.example.team_23_kotlin.data.purchases.PurchaseEntity
+
+data class PurchasesState(
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val purchases: List<PurchaseEntity> = emptyList(),
+    val filteredPurchases: List<PurchaseEntity> = emptyList(),
+    val currentTab: PurchasesTab = PurchasesTab.ALL,
+
+    val totalPurchased: Int = 0,
+    val totalCompleted: Int = 0,
+    val totalPending: Int = 0
+)
+
+enum class PurchasesTab { ALL, PENDING, COMPLETED }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesViewModel.kt
@@ -1,0 +1,298 @@
+package com.example.team_23_kotlin.presentation.purchases
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.graphics.drawable.toBitmap
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import coil.ImageLoader
+import coil.request.ImageRequest
+import coil.request.SuccessResult
+import com.example.team_23_kotlin.R
+import com.example.team_23_kotlin.data.purchases.PurchaseEntity
+import com.example.team_23_kotlin.domain.repository.PurchasesRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltViewModel
+class PurchasesViewModel @Inject constructor(
+    private val repository: PurchasesRepository,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(PurchasesState())
+    val state = _state.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<String>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
+    val logoBitmap = BitmapFactory.decodeResource(context.resources, R.drawable.ic_logo_goat)
+
+
+    init {
+        loadPurchases()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    fun onEvent(event: PurchasesEvent) {
+        when (event) {
+            is PurchasesEvent.OnRefresh -> loadPurchases()
+            is PurchasesEvent.OnTabChange -> {
+                _state.update { it.copy(currentTab = event.tab) }
+                applyFilter()
+            }
+            is PurchasesEvent.OnDownloadReceipt -> {
+                if (event.purchase.isDownloaded) {
+                    // 👇 Ya estaba descargado → solo abrir
+                    openExistingReceipt(event.purchase)
+                } else {
+                    // 👇 No estaba descargado → generar PDF nuevo
+                    generatePdfReceipt(event.purchase)
+                }
+            }
+        }
+    }
+
+
+    private fun loadPurchases() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, error = null) }
+
+            try {
+                val purchases = repository.getPurchases()
+
+                // Integrar si ya están descargados
+                val enriched = purchases.map { p ->
+                    val downloaded = repository.isReceiptGenerated(p.id)
+                    p.copy(isDownloaded = downloaded)
+                }
+
+                _state.update {
+                    it.copy(
+                        purchases = enriched,
+                        isLoading = false,
+                        error = null
+                    )
+                }
+
+                computeStats()
+                applyFilter()
+
+            } catch (e: Exception) {
+                _state.update { it.copy(isLoading = false, error = e.message) }
+            }
+        }
+    }
+
+    private fun computeStats() {
+        val purchases = _state.value.purchases
+        _state.update {
+            it.copy(
+                totalPurchased = purchases.size,
+                totalCompleted = purchases.count { p -> p.status == "completed" },
+                totalPending = purchases.count { p -> p.status == "pending" }
+            )
+        }
+    }
+
+    private fun applyFilter() {
+        val st = _state.value
+
+        val filtered = when (st.currentTab) {
+            PurchasesTab.ALL -> st.purchases
+            PurchasesTab.PENDING -> st.purchases.filter { it.status == "pending" }
+            PurchasesTab.COMPLETED -> st.purchases.filter { it.status == "completed" }
+        }
+
+        _state.update { it.copy(filteredPurchases = filtered) }
+    }
+
+    private suspend fun loadImageBitmap(url: String): Bitmap? {
+        return try {
+            val loader = ImageLoader(context)
+            val request = ImageRequest.Builder(context)
+                .data(url)
+                .allowHardware(false)
+                .build()
+
+            val result = loader.execute(request) as SuccessResult
+            result.drawable.toBitmap()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun generatePdfReceipt(purchase: PurchaseEntity) {
+        viewModelScope.launch(Dispatchers.IO) {
+
+            _uiEvent.emit("Generando recibo en segundo plano...")
+
+            try {
+                val pdf = android.graphics.pdf.PdfDocument()
+                val pageInfo = android.graphics.pdf.PdfDocument.PageInfo.Builder(500, 700, 1).create()
+                val page = pdf.startPage(pageInfo)
+
+                val canvas = page.canvas
+                val paint = android.graphics.Paint()
+
+// ----- Título -----
+                paint.textSize = 24f
+                paint.isFakeBoldText = true
+                canvas.drawText("Recibo de Compra", 30f, 60f, paint)
+
+// ----- Logo de la app -----
+                logoBitmap?.let {
+                    val scaledLogo = Bitmap.createScaledBitmap(it, 90, 90, true)
+                    canvas.drawBitmap(scaledLogo, 360f, 20f, null)
+                }
+
+// ----- Línea separadora -----
+                paint.strokeWidth = 2f
+                canvas.drawLine(20f, 90f, 520f, 90f, paint)
+
+// ----- Texto principal -----
+                paint.textSize = 16f
+                paint.isFakeBoldText = false
+                var y = 130f
+
+                canvas.drawText("Producto: ${purchase.title}", 30f, y, paint); y += 35
+                canvas.drawText("Vendedor: ${purchase.sellerName}", 30f, y, paint); y += 35
+                canvas.drawText("Precio: $${purchase.price}", 30f, y, paint); y += 35
+                canvas.drawText("Fecha: ${purchase.createdAt}", 30f, y, paint); y += 35
+                canvas.drawText("ID de compra: ${purchase.id}", 30f, y, paint)
+                y += 60
+
+// ----- Imagen del producto -----
+                val productBitmap = purchase.postImages.firstOrNull()?.let { loadImageBitmap(it) }
+                productBitmap?.let {
+                    val scaledProduct = Bitmap.createScaledBitmap(it, 300, 300, true)
+                    canvas.drawBitmap(scaledProduct, 100f, y, null)
+                    y += 330
+                }
+
+// ----- Línea final -----
+                canvas.drawLine(20f, y, 520f, y, paint)
+
+
+                pdf.finishPage(page)
+
+                val resolver = context.contentResolver
+                val fileName = "receipt_${purchase.id}.pdf"
+
+                val contentValues = android.content.ContentValues().apply {
+                    put(android.provider.MediaStore.Downloads.DISPLAY_NAME, fileName)
+                    put(android.provider.MediaStore.Downloads.MIME_TYPE, "application/pdf")
+                    put(android.provider.MediaStore.Downloads.RELATIVE_PATH, "Download/")
+                }
+
+                val uri = resolver.insert(
+                    android.provider.MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                    contentValues
+                ) ?: throw Exception("No se pudo crear archivo en Downloads")
+
+                resolver.openOutputStream(uri)?.use { output ->
+                    pdf.writeTo(output)
+                }
+
+                pdf.close()
+
+                _uiEvent.emit("Recibo guardado en Descargas")
+
+                // Guardar en Room
+                repository.markReceiptGenerated(purchase.id)
+
+                // Actualizar UI
+                withContext(Dispatchers.Main) {
+                    val updated = _state.value.purchases.map {
+                        if (it.id == purchase.id) it.copy(isDownloaded = true)
+                        else it
+                    }
+
+                    _state.update { it.copy(purchases = updated) }
+                    applyFilter()
+                }
+
+                openPdf(uri)
+
+            } catch (e: Exception) {
+                _uiEvent.emit("Error generando PDF: ${e.message}")
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun openExistingReceipt(purchase: PurchaseEntity) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val resolver = context.contentResolver
+                val fileName = "receipt_${purchase.id}.pdf"
+
+                val projection = arrayOf(
+                    android.provider.MediaStore.Downloads._ID,
+                    android.provider.MediaStore.Downloads.DISPLAY_NAME
+                )
+                val selection = "${android.provider.MediaStore.Downloads.DISPLAY_NAME} = ?"
+                val selectionArgs = arrayOf(fileName)
+
+                val cursor = resolver.query(
+                    android.provider.MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                    projection,
+                    selection,
+                    selectionArgs,
+                    null
+                )
+
+                cursor?.use {
+                    if (it.moveToFirst()) {
+                        val idColumn = it.getColumnIndexOrThrow(android.provider.MediaStore.Downloads._ID)
+                        val id = it.getLong(idColumn)
+
+                        val uri = android.content.ContentUris.withAppendedId(
+                            android.provider.MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                            id
+                        )
+
+                        _uiEvent.emit("Abriendo recibo desde Descargas")
+                        openPdf(uri)
+                        return@launch
+                    }
+                }
+
+                // ❗ Si no se encuentra el archivo (lo borraron, etc.)
+                _uiEvent.emit("No encontré el recibo en Descargas, generando uno nuevo…")
+                generatePdfReceipt(purchase)
+
+            } catch (e: Exception) {
+                _uiEvent.emit("Error al abrir el recibo, generando uno nuevo…")
+                generatePdfReceipt(purchase)
+            }
+        }
+    }
+
+
+    private suspend fun openPdf(uri: android.net.Uri) {
+        withContext(Dispatchers.Main) {
+            try {
+                val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
+                    setDataAndType(uri, "application/pdf")
+                    flags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                            android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+
+                context.startActivity(intent)
+            } catch (e: Exception) {
+                _uiEvent.emit("No se pudo abrir el PDF")
+            }
+        }
+    }
+}

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+    <foreground android:drawable="@drawable/ic_logo_goat" />
+    <monochrome android:drawable="@drawable/ic_logo_goat" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+    <foreground android:drawable="@drawable/ic_logo_goat" />
+    <monochrome android:drawable="@drawable/ic_logo_goat" />
 </adaptive-icon>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Team-23-Kotlin</string>
+    <string name="app_name">Mercandes</string>
     <string name="action_settings">Settings</string>
     <!-- Strings used for fragments for navigation -->
     <string name="first_fragment_label">First Fragment</string>


### PR DESCRIPTION
This commit introduces the "My Purchases" feature, allowing users to view a list of their past purchases.

Key changes include:
- A new "My Purchases" screen that displays a filterable list of all, pending, and completed purchases.
- Addition of a `PurchasesRepository` and `PurchasesViewModel` to fetch purchase data from Firestore and manage UI state.
- Implementation of PDF receipt generation for each purchase, which can be downloaded and opened from the app.
- Integration of a Room database (`ReceiptDao`) to track which receipts have already been downloaded, preventing re-generation.
- A "Purchases" button is added to the user profile screen for navigation.
- The application name is updated to "Mercandes" and the app icon has been changed.

closes #126 