### PR TITLE
Refactor(EditProfile): Use `firstOrNull` to prevent multiple updates

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-11-19T03:19:10.636811Z">
+        <DropdownSelection timestamp="2025-12-02T23:31:18.106245400Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=R5CY12WRTYX" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation("com.google.dagger:hilt-android:2.57.1")
     implementation(libs.gms.play.services.maps)
     implementation(libs.androidx.compose.foundation.foundation)
+    implementation(libs.androidx.compose.runtime)
     kapt("com.google.dagger:hilt-android-compiler:2.57.1")
     implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
 

--- a/app/src/main/java/com/example/team_23_kotlin/data/repository/PurchasesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/data/repository/PurchasesRepositoryImpl.kt
@@ -33,15 +33,19 @@ class PurchasesRepositoryImpl @Inject constructor(
 
     @RequiresApi(Build.VERSION_CODES.O)
     override suspend fun getPurchases(): List<PurchaseEntity> {
-        // 1. Si ya tenemos cache, devolverla inmediatamente
-        if (purchasesLruCache.size() > 0) {
-            val cachedList = purchasesLruCache.snapshot().values.toList()
-            if (cachedList.isNotEmpty()) return cachedList
+
+        val cachedList = purchasesLruCache.snapshot().values.toList()
+
+        // 🔥 1. Primero devolver cache (fast UI)
+        if (cachedList.isNotEmpty()) {
+            // Pero NO retornamos aún...
+            // dejamos que siga a intentar servidor
         }
 
         return try {
-            val uid = FirebaseAuth.getInstance().uid ?: return emptyList()
+            val uid = FirebaseAuth.getInstance().uid ?: return cachedList
 
+            // 🔥 2. Intentar refrescar desde servidor siempre que sea posible
             val snapshot = db.collection(COLLECTION_SALES)
                 .whereEqualTo("buyer_ref", db.document("$COLLECTION_USERS/$uid"))
                 .get(Source.SERVER)
@@ -51,7 +55,8 @@ class PurchasesRepositoryImpl @Inject constructor(
                 mapToPurchaseEntity(doc)
             }
 
-            // 🔥 GUARDAR EN CACHE LRU
+            // 🔥 3. Actualizar cache con los nuevos datos
+            purchasesLruCache.evictAll()
             purchases.forEach { purchase ->
                 purchasesLruCache.put(purchase.id, purchase)
             }
@@ -60,17 +65,11 @@ class PurchasesRepositoryImpl @Inject constructor(
 
         } catch (e: Exception) {
 
-            // 🔥 Si falla Firestore: regresar lo que haya en cache
-            val cached = mutableListOf<PurchaseEntity>()
-            for (key in purchasesLruCache.snapshot().keys) {
-                purchasesLruCache.get(key)?.let { cached.add(it) }
-            }
-
-            if (cached.isNotEmpty()) return cached
-
-            emptyList()
+            // ❗ 4. Si falla servidor → usar cache como fallback
+            if (cachedList.isNotEmpty()) cachedList else emptyList()
         }
     }
+
 
 
     override suspend fun savePurchasesToLocal(purchases: List<PurchaseEntity>) {

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/navegation/AppNavHost.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/navegation/AppNavHost.kt
@@ -64,6 +64,7 @@ import com.example.team_23_kotlin.presentation.confirmpurchase.ConfirmPurchaseVi
 import com.example.team_23_kotlin.presentation.purchases.PurchasesScreen
 import com.example.team_23_kotlin.presentation.sales.SalesScreen
 import com.example.team_23_kotlin.presentation.feedback.FeedbackScreen
+import com.example.team_23_kotlin.presentation.reviews.ReviewsScreen
 
 
 /** ===================== Rutas ===================== **/
@@ -94,6 +95,9 @@ object Routes {
 
     const val FEEDBACK = "feedback/{purchaseId}/{sellerId}"
     fun feedback(purchaseId: String, sellerId: String) = "feedback/${Uri.encode(purchaseId)}/${Uri.encode(sellerId)}"
+
+    const val REVIEWS = "reviews/{postId}"
+    fun reviews(postId: String) = "reviews/${Uri.encode(postId)}"
 
 }
 
@@ -449,6 +453,18 @@ fun AppNavHost(
             ) {
                 FeedbackScreen(navController = nav)
             }
+
+            composable(
+                route = Routes.REVIEWS,
+                arguments = listOf(navArgument("postId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val postId = backStackEntry.arguments?.getString("postId") ?: return@composable
+                ReviewsScreen(
+                    postId = postId,
+                    onBack = { nav.popBackStack() }
+                )
+            }
+
 
         }
     }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/product/ProductScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/product/ProductScreen.kt
@@ -54,6 +54,7 @@ import android.net.Uri
 import android.util.Log
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.ui.res.painterResource
+import com.example.team_23_kotlin.presentation.navegation.Routes
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.maps.android.compose.MapProperties
@@ -305,6 +306,27 @@ fun ProductScreen(
 
 
                         Spacer(Modifier.height(20.dp))
+
+// ⭐ NEW: See Reviews Button
+                        Button(
+                            onClick = {
+                                state.product?.let { product ->
+                                    nav.navigate(Routes.reviews(product.id))
+                                }
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(50.dp),
+                            shape = RoundedCornerShape(12.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.tertiary
+                            )
+                        ) {
+                            Text("See Reviews", style = MaterialTheme.typography.titleSmall)
+                        }
+
+                        Spacer(Modifier.height(20.dp))
+
                     }
                 }
             }

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/purchases/PurchasesScreen.kt
@@ -52,7 +52,7 @@ fun PurchasesScreen(
             }
         } else {
             wasOffline = true
-            snackbarHostState.showSnackbar("Conexión perdida. Mostrando compras guardadas.")
+            snackbarHostState.showSnackbar("Conexión perdida. Mostrando compras guardadas. Solo verás las últimas 10 compras en modo offline!")
         }
     }
     val context = LocalContext.current

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/reviews/ReviewsEvent.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/reviews/ReviewsEvent.kt
@@ -1,0 +1,5 @@
+package com.example.team_23_kotlin.presentation.reviews
+
+sealed class ReviewsEvent {
+    data class LoadReviews(val postId: String) : ReviewsEvent()
+}

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/reviews/ReviewsScreen.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/reviews/ReviewsScreen.kt
@@ -1,0 +1,196 @@
+package com.example.team_23_kotlin.presentation.reviews
+
+import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import com.example.team_23_kotlin.presentation.shared.rememberConnectivityStatus
+import java.text.SimpleDateFormat
+import java.util.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReviewsScreen(
+    postId: String,
+    viewModel: ReviewsViewModel = hiltViewModel(),
+    onBack: () -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val isConnected by rememberConnectivityStatus()
+    var wasOffline by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isConnected) {
+        if (!isConnected) {
+            wasOffline = true
+            snackbarHostState.showSnackbar(
+                "Conexión perdida. Mostrando reviews guardados. Solo verás los últimos 10."
+            )
+        } else if (wasOffline) {
+            snackbarHostState.showSnackbar("Conexión restaurada. Actualizando…")
+            viewModel.onEvent(ReviewsEvent.LoadReviews(postId))
+            wasOffline = false
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.onEvent(ReviewsEvent.LoadReviews(postId))
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        "Reviews",
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = Color.White
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Filled.ArrowBack, null, tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { padding ->
+
+        when {
+            state.isLoading -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+
+            state.reviews.isEmpty() -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                Alignment.Center
+            ) {
+                Text("No reviews yet.", color = Color.Gray)
+            }
+
+            else -> LazyColumn(
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                items(state.reviews) { review ->
+                    ReviewCard(review = review)
+                }
+            }
+        }
+    }
+}
+@Composable
+fun ReviewCard(review: ReviewUi) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
+
+            // ⭐ Primera fila: avatar + nombre + rating
+            Row(
+                Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Filled.Person,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(32.dp)
+                )
+
+                Spacer(Modifier.width(12.dp))
+
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        review.reviewerName,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Bold
+                        )
+                    )
+                    Text(
+                        formatReviewDate(review.createdAt),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.Gray
+                    )
+                }
+
+                Text(
+                    text = "⭐ ${review.rating}",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // ⭐ Comentario
+            Text(
+                review.comment,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.Black
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // ⭐ Galería de fotos (si existen)
+            if (review.images.isNotEmpty()) {
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    review.images.forEach { imageUrl ->
+                        AsyncImage(
+                            model = imageUrl,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(110.dp)
+                                .clip(RoundedCornerShape(12.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+fun formatReviewDate(timestamp: Long): String {
+    return try {
+        val date = Date(timestamp)
+        val formatter = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+        formatter.format(date)
+    } catch (e: Exception) {
+        ""
+    }
+}
+

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/reviews/ReviewsState.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/reviews/ReviewsState.kt
@@ -1,0 +1,16 @@
+package com.example.team_23_kotlin.presentation.reviews
+
+data class ReviewsState(
+    val isLoading: Boolean = false,
+    val reviews: List<ReviewUi> = emptyList(),
+    val errorMessage: String? = null
+)
+
+data class ReviewUi(
+    val rating: Int,
+    val comment: String,
+    val images: List<String>,
+    val reviewerName: String,
+    val reviewerImage: String? = null,
+    val createdAt: Long
+)

--- a/app/src/main/java/com/example/team_23_kotlin/presentation/reviews/ReviewsViewModel.kt
+++ b/app/src/main/java/com/example/team_23_kotlin/presentation/reviews/ReviewsViewModel.kt
@@ -1,0 +1,121 @@
+package com.example.team_23_kotlin.presentation.reviews
+
+import android.util.LruCache
+import androidx.lifecycle.ViewModel
+import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+@HiltViewModel
+class ReviewsViewModel @Inject constructor(
+    private val firestore: FirebaseFirestore
+) : ViewModel() {
+
+    // ⭐ LRU Cache integrado en el ViewModel
+    private val reviewsCache = object : LruCache<String, List<ReviewUi>>(10) {}
+
+    private val _state = MutableStateFlow(ReviewsState())
+    val state = _state.asStateFlow()
+
+    fun onEvent(event: ReviewsEvent) {
+        when (event) {
+            is ReviewsEvent.LoadReviews -> loadReviews(event.postId)
+        }
+    }
+
+    private fun loadReviews(postId: String) {
+
+        // ⭐ 1. Lectura instantánea desde cache (Eventual Connectivity)
+        val cachedReviews = reviewsCache.get(postId)
+        if (cachedReviews != null) {
+            _state.update {
+                it.copy(
+                    reviews = cachedReviews,
+                    isLoading = false
+                )
+            }
+        }
+
+        // ⭐ 2. Intentar obtener online
+        _state.update { it.copy(isLoading = true) }
+
+        firestore.collection("sales")
+            .whereEqualTo("post_ref", firestore.document("posts/$postId"))
+            .whereEqualTo("status", "completed")
+            .get()
+            .addOnSuccessListener { salesSnapshot ->
+
+                val saleIds = salesSnapshot.documents.mapNotNull { it.id }
+
+                if (saleIds.isEmpty()) {
+                    _state.update { it.copy(isLoading = false, reviews = emptyList()) }
+                    return@addOnSuccessListener
+                }
+
+                firestore.collection("feedbacks")
+                    .whereIn("purchaseId", saleIds)
+                    .get()
+                    .addOnSuccessListener { feedbackSnapshot ->
+
+                        val feedbacks = feedbackSnapshot.documents
+
+                        if (feedbacks.isEmpty()) {
+                            _state.update { it.copy(isLoading = false, reviews = emptyList()) }
+                            return@addOnSuccessListener
+                        }
+
+                        val userIds = feedbacks.mapNotNull { it.getString("buyerId") }.distinct()
+
+                        firestore.collection("users")
+                            .whereIn(FieldPath.documentId(), userIds)
+                            .get()
+                            .addOnSuccessListener { usersSnapshot ->
+
+                                val userMap = usersSnapshot.documents.associateBy { it.id }
+
+                                val reviewUiList = feedbacks.mapNotNull { doc ->
+
+                                    val rating = doc.getLong("rating")?.toInt() ?: return@mapNotNull null
+                                    val comment = doc.getString("comment") ?: ""
+                                    val images = doc.get("images") as? List<String> ?: emptyList()
+                                    val createdAt = doc.getTimestamp("createdAt")?.toDate()?.time ?: 0L
+                                    val buyerId = doc.getString("buyerId") ?: return@mapNotNull null
+
+                                    val userData = userMap[buyerId]
+
+                                    ReviewUi(
+                                        rating = rating,
+                                        comment = comment,
+                                        images = images,
+                                        reviewerName = userData?.getString("name") ?: "Unknown",
+                                        reviewerImage = userData?.getString("profile_image"),
+                                        createdAt = createdAt
+                                    )
+                                }.sortedByDescending { it.createdAt }
+
+                                // ⭐ 3. Actualizar la cache con los últimos 10
+                                reviewsCache.put(postId, reviewUiList.take(10))
+
+                                _state.update {
+                                    it.copy(
+                                        isLoading = false,
+                                        reviews = reviewUiList
+                                    )
+                                }
+                            }
+                    }
+            }
+            .addOnFailureListener { e ->
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = e.localizedMessage
+                    )
+                }
+            }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ firebaseBom = "33.3.0"
 firebaseStorageKtx = "22.0.1"
 playServicesMaps = "19.2.0"
 foundationVersion = "1.9.4"
+runtime = "1.9.5"
 
 [libraries]
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
@@ -82,6 +83,7 @@ firebase-firestore-ktx = { module = "com.google.firebase:firebase-firestore-ktx"
 firebase-storage-ktx = { module = "com.google.firebase:firebase-storage-ktx" }
 gms-play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
 androidx-compose-foundation-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundationVersion" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "runtime" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Changed the profile update logic in `EditProfileViewModel` to use `firstOrNull()` instead of `collect`. This ensures that the user's profile data is fetched and updated in Firestore only once, preventing potential multiple update calls from the Flow.

closes #148 